### PR TITLE
Port of fix from master for crash after 100s on mac after using VideoCapture

### DIFF
--- a/recipe/cap_qtkit_100s_fix.patch
+++ b/recipe/cap_qtkit_100s_fix.patch
@@ -1,7 +1,6 @@
----modules/highgui/src/cap_qtkit.mm
-+++modules/highgui/src/cap_qtkit.mm
-@@ -95,6 +95,8 @@
- - (void)captureOutput:(QTCaptureOutput *)captureOutput
+--- a/modules/highgui/src/cap_qtkit.mm
++++ b/modules/highgui/src/cap_qtkit.mm
+@@ -95,6 +95,8 @@ - (void)captureOutput:(QTCaptureOutput *)captureOutput
  - (int)updateImage;
  - (IplImage*)getOutput;
 
@@ -10,8 +9,7 @@
  @end
 
  /*****************************************************************************
-@@ -625,6 +627,11 @@
- -(int) updateImage {
+@@ -625,6 +627,11 @@ -(int) updateImage {
      return 1;
  }
 

--- a/recipe/cap_qtkit_100s_fix.patch
+++ b/recipe/cap_qtkit_100s_fix.patch
@@ -1,0 +1,23 @@
+---modules/highgui/src/cap_qtkit.mm
++++modules/highgui/src/cap_qtkit.mm
+@@ -95,6 +95,8 @@
+ - (void)captureOutput:(QTCaptureOutput *)captureOutput
+ - (int)updateImage;
+ - (IplImage*)getOutput;
+
++- (void)doFireTimer:(NSTimer *)timer;
++
+ @end
+
+ /*****************************************************************************
+@@ -625,6 +627,11 @@
+ -(int) updateImage {
+     return 1;
+ }
+
++- (void)doFireTimer:(NSTimer *)timer {
++    (void)timer;
++    // dummy
++}
++
+ @end

--- a/recipe/cap_qtkit_100s_fix.patch
+++ b/recipe/cap_qtkit_100s_fix.patch
@@ -1,5 +1,5 @@
----modules/highgui/src/cap_qtkit.mm
-+++modules/highgui/src/cap_qtkit.mm
+--- modules/highgui/src/cap_qtkit.mm
++++ modules/highgui/src/cap_qtkit.mm
 @@ -95,6 +95,8 @@ - (void)captureOutput:(QTCaptureOutput *)captureOutput
  - (int)updateImage;
  - (IplImage*)getOutput;

--- a/recipe/cap_qtkit_100s_fix.patch
+++ b/recipe/cap_qtkit_100s_fix.patch
@@ -1,5 +1,5 @@
---- modules/highgui/src/cap_qtkit.mm
-+++ modules/highgui/src/cap_qtkit.mm
+--- modules/videoio/src/cap_qtkit.mm
++++ modules/videoio/src/cap_qtkit.mm
 @@ -95,6 +95,8 @@ - (void)captureOutput:(QTCaptureOutput *)captureOutput
  - (int)updateImage;
  - (IplImage*)getOutput;

--- a/recipe/cap_qtkit_100s_fix.patch
+++ b/recipe/cap_qtkit_100s_fix.patch
@@ -1,5 +1,5 @@
---- a/modules/highgui/src/cap_qtkit.mm
-+++ b/modules/highgui/src/cap_qtkit.mm
+---modules/highgui/src/cap_qtkit.mm
++++modules/highgui/src/cap_qtkit.mm
 @@ -95,6 +95,8 @@ - (void)captureOutput:(QTCaptureOutput *)captureOutput
  - (int)updateImage;
  - (IplImage*)getOutput;

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,11 @@ source:
   patches:
     # Fixed: https://github.com/opencv/opencv/blob/master/modules/videoio/src/cap_mjpeg_decoder.cpp#L793
     - cap_mpjpeg_decoder.patch  # [win]
+    # Fixed: https://github.com/opencv/opencv/issues/5874
     - cap_qtkit_100s_fix.patch
 
 build:
-    number: 0
+    number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
   patches:
     # Fixed: https://github.com/opencv/opencv/blob/master/modules/videoio/src/cap_mjpeg_decoder.cpp#L793
     - cap_mpjpeg_decoder.patch  # [win]
+    - cap_qtkit_100s_fix.patch
 
 build:
     number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   patches:
     # Fixed: https://github.com/opencv/opencv/blob/master/modules/videoio/src/cap_mjpeg_decoder.cpp#L793
     - cap_mpjpeg_decoder.patch  # [win]
-    # Fixed: https://github.com/opencv/opencv/issues/5874
+    # Fixed: https://github.com/opencv/opencv/pull/6051
     - cap_qtkit_100s_fix.patch
 
 build:


### PR DESCRIPTION
Closes https://github.com/conda-forge/opencv-feedstock/issues/28

Port of the fix from master OpenCV to the 3.1 branch that fixes a crash after 100s on mac after opening a VideoCapture device.