### PR TITLE
Update HDF5 and OpenSSL pinnings

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python
     - toolchain
     # For sha256 comparisons of opencv_contrib
-    - openssl 1.0.*               # [unix]
+    - openssl 1.0.*         # [unix]
     # For downloading opencv_contrib
     - curl
     # For applying patches
@@ -40,7 +40,7 @@ requirements:
   run:
     - python
     - numpy x.x
-    - hdf5 1.8.17|1.8.17.*          # [unix]
+    - hdf5 1.8.17|1.8.17.*  # [unix]
     - jasper                # [unix]
     - zlib 1.2.*
     - jpeg 9*


### PR DESCRIPTION
Closes https://github.com/conda-forge/opencv-feedstock/pull/30
Closes https://github.com/conda-forge/opencv-feedstock/pull/36

Takes over PR ( https://github.com/conda-forge/opencv-feedstock/pull/30 ) and merges it into the now re-rendered `master` branch.