### PR TITLE
Upgrade to hdf5 1.8.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - opencv_core_int64_abs.patch           # [win and py<35]
 
 build:
-  number: 202
+  number: 203
   features:                    # [not win]
     - blas_{{ blas_variant }}  # [not win]
 
@@ -36,7 +36,7 @@ requirements:
     - git                          # [win]
     - cmake
     - numpy x.x
-    - hdf5 1.8.17|1.8.17.*         # [unix]
+    - hdf5 1.8.18|1.8.18.*         # [unix]
     - eigen 3.2.*
     - jasper                       # [unix]
     - zlib 1.2.*
@@ -53,7 +53,7 @@ requirements:
   run:
     - python
     - numpy x.x
-    - hdf5 1.8.17|1.8.17.*         # [unix]
+    - hdf5 1.8.18|1.8.18.*         # [unix]
     - jasper                       # [unix]
     - zlib 1.2.*
     - jpeg 9*


### PR DESCRIPTION
A few CVEs were reported and fixed in hdf5 back in November 2016: http://blog.talosintelligence.com/2016/11/hdf5-vulns.html

The hdf5 release notes for that release are available here: https://support.hdfgroup.org/ftp/HDF5/current18/src/hdf5-1.8.18-RELEASE.txt

For additional info, please see: https://github.com/conda-forge/hdf5-feedstock/pull/68 and https://github.com/conda-forge/hdf5-feedstock/issues/71