### PR TITLE
Fixes cv2.imshow() on linux & win by adding qt5 to build, update ffmpeg pinning

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -46,6 +46,9 @@ set UNIX_LIBRARY_LIB=%LIBRARY_LIB:\=/%
 set UNIX_SP_DIR=%SP_DIR:\=/%
 set UNIX_SRC_DIR=%SRC_DIR:\=/%
 
+:: cvv and qt5 don't play well on PY27 https://github.com/opencv/opencv_contrib/issues/577
+if "%PY_MAJOR%" == "2" ( set "CVV=off" )
+if "%PY_MAJOR%" == "3" ( set "CVV=on" )
 
 cmake .. -LAH -G "NMake Makefiles"                                                  ^
     -DWITH_EIGEN=1                                                                  ^
@@ -64,8 +67,10 @@ cmake .. -LAH -G "NMake Makefiles"                                              
     -DWITH_OPENNI=0                                                                 ^
     -DWITH_FFMPEG=1                                                                 ^
     -DWITH_VTK=0                                                                    ^
+    -DWITH_QT=5                                                                     ^
     -DINSTALL_C_EXAMPLES=0                                                          ^
     -DOPENCV_EXTRA_MODULES_PATH=%UNIX_SRC_DIR%/opencv_contrib-%PKG_VERSION%/modules ^
+    -DBUILD_opencv_cvv=%CVV%                                                        ^
     -DCMAKE_BUILD_TYPE="Release"                                                    ^
     -DCMAKE_INSTALL_PREFIX=%UNIX_LIBRARY_PREFIX%                                    ^
     -DEXECUTABLE_OUTPUT_PATH=%UNIX_LIBRARY_BIN%                                     ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,7 @@
 set +x
 SHORT_OS_STR=$(uname -s)
 
+QT="5"
 if [ "${SHORT_OS_STR:0:5}" == "Linux" ]; then
     OPENMP="-DWITH_OPENMP=1"
     # Looks like there's a bug in Opencv 3.2.0 for building with FFMPEG
@@ -11,6 +12,7 @@ if [ "${SHORT_OS_STR:0:5}" == "Linux" ]; then
 fi
 if [ "${SHORT_OS_STR}" == "Darwin" ]; then
     OPENMP=""
+    QT="0"
 fi
 
 curl -L -O "https://github.com/opencv/opencv_contrib/archive/$PKG_VERSION.tar.gz"
@@ -102,6 +104,7 @@ cmake .. -LAH                                                             \
     -DWITH_FFMPEG=1                                                       \
     -DWITH_MATLAB=0                                                       \
     -DWITH_VTK=0                                                          \
+    -DWITH_QT=$QT                                                         \
     -DWITH_GPHOTO2=0                                                      \
     -DINSTALL_C_EXAMPLES=0                                                \
     -DOPENCV_EXTRA_MODULES_PATH="../opencv_contrib-$PKG_VERSION/modules"  \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - opencv_core_int64_abs.patch           # [win and py<35]
 
 build:
-  number: 203
+  number: 204
   features:                    # [not win]
     - blas_{{ blas_variant }}  # [not win]
 
@@ -49,6 +49,7 @@ requirements:
     - openblas 0.2.19|0.2.19.*     # [not win]
     - blas 1.1 {{ blas_variant }}  # [not win]
     - ffmpeg                       # [not win]
+    - qt 5.6.*                     # [not osx]
 
   run:
     - python
@@ -64,6 +65,7 @@ requirements:
     - openblas 0.2.19|0.2.19.*     # [not win]
     - blas 1.1 {{ blas_variant }}  # [not win]
     - ffmpeg                       # [not win]
+    - qt 5.6.*                     # [not osx]
 
 test:
     imports:
@@ -137,3 +139,4 @@ extra:
     - msarahan
     - patricksnape
     - zym1010
+    - hajapy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - msinttypes                   # [win and py<35]
     - openblas 0.2.19|0.2.19.*     # [not win]
     - blas 1.1 {{ blas_variant }}  # [not win]
-    - ffmpeg                       # [not win]
+    - ffmpeg >=3.2.3,<3.2.6        # [not win]
     - qt 5.6.*                     # [not osx]
 
   run:
@@ -64,7 +64,7 @@ requirements:
     - libpng >=1.6.23,<1.7
     - openblas 0.2.19|0.2.19.*     # [not win]
     - blas 1.1 {{ blas_variant }}  # [not win]
-    - ffmpeg                       # [not win]
+    - ffmpeg >=3.2.3,<3.2.6        # [not win]
     - qt 5.6.*                     # [not osx]
 
 test:


### PR DESCRIPTION
Attempts to resolve https://github.com/conda-forge/opencv-feedstock/issues/79 but this time using qt5 on all platforms as recommended by @jakirkham.

First let's see if the builds work, then we should evaluate the build packages to ensure the cv2.imshow() operation actually works. I'm not sure how to instrument this test on the CI. 

If this works, it should be preferred to https://github.com/conda-forge/opencv-feedstock/pull/80