### PR TITLE
Fix for OpenCVModules.cmake and OpenCVConfig.cmake in windows.

### DIFF
--- a/recipe/112_win_fix_cmake_config_sufix.patch
+++ b/recipe/112_win_fix_cmake_config_sufix.patch
@@ -1,0 +1,40 @@
+--- CMakeLists.txt.orig
++++ CMakeLists.txt
+@@ -373,7 +373,7 @@
+ 
+ if(WIN32 AND CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
+   if(DEFINED OpenCV_RUNTIME AND DEFINED OpenCV_ARCH)
+-    ocv_update(OpenCV_INSTALL_BINARIES_PREFIX "${OpenCV_ARCH}/${OpenCV_RUNTIME}/")
++    ocv_update(OpenCV_INSTALL_BINARIES_PREFIX "")
+   else()
+     message(STATUS "Can't detect runtime and/or arch")
+     ocv_update(OpenCV_INSTALL_BINARIES_PREFIX "")
+
+--- cmake\templates\OpenCVConfig.root-WIN32.cmake.in.orig
++++ cmake\templates\OpenCVConfig.root-WIN32.cmake.in
+@@ -105,17 +105,21 @@
+ 
+ get_filename_component(OpenCV_CONFIG_PATH "${CMAKE_CURRENT_LIST_FILE}" PATH)
+ if(OpenCV_RUNTIME AND OpenCV_ARCH)
+-  if(OpenCV_STATIC AND EXISTS "${OpenCV_CONFIG_PATH}/${OpenCV_ARCH}/${OpenCV_RUNTIME}/staticlib/OpenCVConfig.cmake")
++  # broke in windows see https://github.com/conda-forge/opencv-feedstock/issues/41
++  if(OpenCV_STATIC AND EXISTS "${OpenCV_CONFIG_PATH}/lib/OpenCVConfig.cmake")
++    # cuda not available in windows see https://github.com/conda-forge/opencv-feedstock/issues/109
+     if(OpenCV_CUDA AND EXISTS "${OpenCV_CONFIG_PATH}/gpu/${OpenCV_ARCH}/${OpenCV_RUNTIME}/staticlib/OpenCVConfig.cmake")
+       set(OpenCV_LIB_PATH "${OpenCV_CONFIG_PATH}/gpu/${OpenCV_ARCH}/${OpenCV_RUNTIME}/staticlib")
+     else()
+-      set(OpenCV_LIB_PATH "${OpenCV_CONFIG_PATH}/${OpenCV_ARCH}/${OpenCV_RUNTIME}/staticlib")
++      set(OpenCV_LIB_PATH "${OpenCV_CONFIG_PATH}/lib")
+     endif()
+-  elseif(EXISTS "${OpenCV_CONFIG_PATH}/${OpenCV_ARCH}/${OpenCV_RUNTIME}/lib/OpenCVConfig.cmake")
++  # shared libs (dlls)
++  elseif(EXISTS "${OpenCV_CONFIG_PATH}/lib/OpenCVConfig.cmake")
++    # cuda not available in windows see https://github.com/conda-forge/opencv-feedstock/issues/109
+     if(OpenCV_CUDA AND EXISTS "${OpenCV_CONFIG_PATH}/gpu/${OpenCV_ARCH}/${OpenCV_RUNTIME}/lib/OpenCVConfig.cmake")
+       set(OpenCV_LIB_PATH "${OpenCV_CONFIG_PATH}/gpu/${OpenCV_ARCH}/${OpenCV_RUNTIME}/lib")
+     else()
+-      set(OpenCV_LIB_PATH "${OpenCV_CONFIG_PATH}/${OpenCV_ARCH}/${OpenCV_RUNTIME}/lib")
++      set(OpenCV_LIB_PATH "${OpenCV_CONFIG_PATH}/bin")
+     endif()
+   endif()
+ endif()

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,9 @@ source:
     fn: opencv-{{ version }}.tar.gz
     sha256: 4eef85759d5450b183459ff216b4c0fa43e87a4f6aa92c8af649f89336f002ec
     patches:
+      patches:
+      # https://github.com/conda-forge/opencv-feedstock/pull/112
+      - 112_win_fix_cmake_config_sufix.patch  # [win]
       # https://github.com/opencv/opencv/pull/12465
       - 12465-bayer2rgba.patch
       # https://github.com/opencv/opencv/pull/12515

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
     fn: opencv-{{ version }}.tar.gz
     sha256: 4eef85759d5450b183459ff216b4c0fa43e87a4f6aa92c8af649f89336f002ec
     patches:
-      patches:
       # https://github.com/conda-forge/opencv-feedstock/pull/112
       - 112_win_fix_cmake_config_sufix.patch  # [win]
       # https://github.com/opencv/opencv/pull/12465


### PR DESCRIPTION
* Fixes OpenCVModules.cmake and OpenCVConfig.cmake library location in Windows.
** As it was broken and did not allowed cmake find_package(OpenCV) to be used from other cmake files.
* Updated the recipe to work with conda-build 3
* Added multiple sources in the meta.yml instead of having dowloaded in the bld.bat and build.sh
