### PR TITLE
build without gstreamer

### DIFF
--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -5,7 +5,7 @@ cxx_compiler:
 ffmpeg:
 - '4.0'
 harfbuzz:
-- '1.7'
+- '1'
 hdf5:
 - 1.10.2
 jpeg:
@@ -24,7 +24,7 @@ pin_run_as_build:
   ffmpeg:
     max_pin: x.x
   harfbuzz:
-    max_pin: x.x
+    max_pin: x
   hdf5:
     max_pin: x.x.x
   jpeg:
@@ -38,8 +38,8 @@ pin_run_as_build:
   openblas:
     max_pin: x.x.x
   python:
-    min_pin: x.x
     max_pin: x.x
+    min_pin: x.x
   qt:
     max_pin: x.x
   zlib:

--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -8,6 +8,8 @@ harfbuzz:
 - '1'
 hdf5:
 - 1.10.2
+jasper:
+- 1.900.1
 jpeg:
 - '9'
 libpng:
@@ -27,6 +29,8 @@ pin_run_as_build:
     max_pin: x
   hdf5:
     max_pin: x.x.x
+  jasper:
+    max_pin: x
   jpeg:
     max_pin: x
   libpng:
@@ -38,8 +42,8 @@ pin_run_as_build:
   openblas:
     max_pin: x.x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   qt:
     max_pin: x.x
   zlib:

--- a/.ci_support/linux_python3.5.yaml
+++ b/.ci_support/linux_python3.5.yaml
@@ -5,7 +5,7 @@ cxx_compiler:
 ffmpeg:
 - '4.0'
 harfbuzz:
-- '1.7'
+- '1'
 hdf5:
 - 1.10.2
 jpeg:
@@ -24,7 +24,7 @@ pin_run_as_build:
   ffmpeg:
     max_pin: x.x
   harfbuzz:
-    max_pin: x.x
+    max_pin: x
   hdf5:
     max_pin: x.x.x
   jpeg:
@@ -38,8 +38,8 @@ pin_run_as_build:
   openblas:
     max_pin: x.x.x
   python:
-    min_pin: x.x
     max_pin: x.x
+    min_pin: x.x
   qt:
     max_pin: x.x
   zlib:

--- a/.ci_support/linux_python3.5.yaml
+++ b/.ci_support/linux_python3.5.yaml
@@ -8,6 +8,8 @@ harfbuzz:
 - '1'
 hdf5:
 - 1.10.2
+jasper:
+- 1.900.1
 jpeg:
 - '9'
 libpng:
@@ -27,6 +29,8 @@ pin_run_as_build:
     max_pin: x
   hdf5:
     max_pin: x.x.x
+  jasper:
+    max_pin: x
   jpeg:
     max_pin: x
   libpng:
@@ -38,8 +42,8 @@ pin_run_as_build:
   openblas:
     max_pin: x.x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   qt:
     max_pin: x.x
   zlib:

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -5,7 +5,7 @@ cxx_compiler:
 ffmpeg:
 - '4.0'
 harfbuzz:
-- '1.7'
+- '1'
 hdf5:
 - 1.10.2
 jpeg:
@@ -24,7 +24,7 @@ pin_run_as_build:
   ffmpeg:
     max_pin: x.x
   harfbuzz:
-    max_pin: x.x
+    max_pin: x
   hdf5:
     max_pin: x.x.x
   jpeg:
@@ -38,8 +38,8 @@ pin_run_as_build:
   openblas:
     max_pin: x.x.x
   python:
-    min_pin: x.x
     max_pin: x.x
+    min_pin: x.x
   qt:
     max_pin: x.x
   zlib:

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -8,6 +8,8 @@ harfbuzz:
 - '1'
 hdf5:
 - 1.10.2
+jasper:
+- 1.900.1
 jpeg:
 - '9'
 libpng:
@@ -27,6 +29,8 @@ pin_run_as_build:
     max_pin: x
   hdf5:
     max_pin: x.x.x
+  jasper:
+    max_pin: x
   jpeg:
     max_pin: x
   libpng:
@@ -38,8 +42,8 @@ pin_run_as_build:
   openblas:
     max_pin: x.x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   qt:
     max_pin: x.x
   zlib:

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -7,7 +7,7 @@ cxx_compiler:
 ffmpeg:
 - '4.0'
 harfbuzz:
-- '1.7'
+- '1'
 hdf5:
 - 1.10.2
 jpeg:
@@ -30,7 +30,7 @@ pin_run_as_build:
   ffmpeg:
     max_pin: x.x
   harfbuzz:
-    max_pin: x.x
+    max_pin: x
   hdf5:
     max_pin: x.x.x
   jpeg:
@@ -44,15 +44,11 @@ pin_run_as_build:
   openblas:
     max_pin: x.x.x
   python:
+    max_pin: x.x
     min_pin: x.x
-    max_pin: x.x
-  qt:
-    max_pin: x.x
   zlib:
     max_pin: x.x
 python:
 - '2.7'
-qt:
-- '5.6'
 zlib:
 - '1.2'

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -10,6 +10,8 @@ harfbuzz:
 - '1'
 hdf5:
 - 1.10.2
+jasper:
+- 1.900.1
 jpeg:
 - '9'
 libpng:
@@ -33,6 +35,8 @@ pin_run_as_build:
     max_pin: x
   hdf5:
     max_pin: x.x.x
+  jasper:
+    max_pin: x
   jpeg:
     max_pin: x
   libpng:
@@ -44,8 +48,8 @@ pin_run_as_build:
   openblas:
     max_pin: x.x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:

--- a/.ci_support/osx_python3.5.yaml
+++ b/.ci_support/osx_python3.5.yaml
@@ -10,6 +10,8 @@ harfbuzz:
 - '1'
 hdf5:
 - 1.10.2
+jasper:
+- 1.900.1
 jpeg:
 - '9'
 libpng:
@@ -33,6 +35,8 @@ pin_run_as_build:
     max_pin: x
   hdf5:
     max_pin: x.x.x
+  jasper:
+    max_pin: x
   jpeg:
     max_pin: x
   libpng:
@@ -44,8 +48,8 @@ pin_run_as_build:
   openblas:
     max_pin: x.x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:

--- a/.ci_support/osx_python3.5.yaml
+++ b/.ci_support/osx_python3.5.yaml
@@ -7,7 +7,7 @@ cxx_compiler:
 ffmpeg:
 - '4.0'
 harfbuzz:
-- '1.7'
+- '1'
 hdf5:
 - 1.10.2
 jpeg:
@@ -30,7 +30,7 @@ pin_run_as_build:
   ffmpeg:
     max_pin: x.x
   harfbuzz:
-    max_pin: x.x
+    max_pin: x
   hdf5:
     max_pin: x.x.x
   jpeg:
@@ -44,15 +44,11 @@ pin_run_as_build:
   openblas:
     max_pin: x.x.x
   python:
+    max_pin: x.x
     min_pin: x.x
-    max_pin: x.x
-  qt:
-    max_pin: x.x
   zlib:
     max_pin: x.x
 python:
 - '3.5'
-qt:
-- '5.6'
 zlib:
 - '1.2'

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -7,7 +7,7 @@ cxx_compiler:
 ffmpeg:
 - '4.0'
 harfbuzz:
-- '1.7'
+- '1'
 hdf5:
 - 1.10.2
 jpeg:
@@ -30,7 +30,7 @@ pin_run_as_build:
   ffmpeg:
     max_pin: x.x
   harfbuzz:
-    max_pin: x.x
+    max_pin: x
   hdf5:
     max_pin: x.x.x
   jpeg:
@@ -44,15 +44,11 @@ pin_run_as_build:
   openblas:
     max_pin: x.x.x
   python:
+    max_pin: x.x
     min_pin: x.x
-    max_pin: x.x
-  qt:
-    max_pin: x.x
   zlib:
     max_pin: x.x
 python:
 - '3.6'
-qt:
-- '5.6'
 zlib:
 - '1.2'

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -10,6 +10,8 @@ harfbuzz:
 - '1'
 hdf5:
 - 1.10.2
+jasper:
+- 1.900.1
 jpeg:
 - '9'
 libpng:
@@ -33,6 +35,8 @@ pin_run_as_build:
     max_pin: x
   hdf5:
     max_pin: x.x.x
+  jasper:
+    max_pin: x
   jpeg:
     max_pin: x
   libpng:
@@ -44,8 +48,8 @@ pin_run_as_build:
   openblas:
     max_pin: x.x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.5.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.5.yaml
@@ -22,8 +22,8 @@ pin_run_as_build:
   libwebp:
     max_pin: x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   qt:
     max_pin: x.x
   zlib:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.5.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.5.yaml
@@ -2,12 +2,6 @@ c_compiler:
 - vs2015
 cxx_compiler:
 - vs2015
-ffmpeg:
-- '4.0'
-harfbuzz:
-- '1.7'
-hdf5:
-- 1.10.2
 jpeg:
 - '9'
 libpng:
@@ -18,15 +12,7 @@ libwebp:
 - '0.5'
 numpy:
 - '1.11'
-openblas:
-- 0.2.20
 pin_run_as_build:
-  ffmpeg:
-    max_pin: x.x
-  harfbuzz:
-    max_pin: x.x
-  hdf5:
-    max_pin: x.x.x
   jpeg:
     max_pin: x
   libpng:
@@ -35,11 +21,9 @@ pin_run_as_build:
     max_pin: x
   libwebp:
     max_pin: x.x
-  openblas:
-    max_pin: x.x.x
   python:
-    min_pin: x.x
     max_pin: x.x
+    min_pin: x.x
   qt:
     max_pin: x.x
   zlib:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.yaml
@@ -22,8 +22,8 @@ pin_run_as_build:
   libwebp:
     max_pin: x.x
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
   qt:
     max_pin: x.x
   zlib:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.yaml
@@ -2,12 +2,6 @@ c_compiler:
 - vs2015
 cxx_compiler:
 - vs2015
-ffmpeg:
-- '4.0'
-harfbuzz:
-- '1.7'
-hdf5:
-- 1.10.2
 jpeg:
 - '9'
 libpng:
@@ -18,15 +12,7 @@ libwebp:
 - '0.5'
 numpy:
 - '1.11'
-openblas:
-- 0.2.20
 pin_run_as_build:
-  ffmpeg:
-    max_pin: x.x
-  harfbuzz:
-    max_pin: x.x
-  hdf5:
-    max_pin: x.x.x
   jpeg:
     max_pin: x
   libpng:
@@ -35,11 +21,9 @@ pin_run_as_build:
     max_pin: x
   libwebp:
     max_pin: x.x
-  openblas:
-    max_pin: x.x.x
   python:
-    min_pin: x.x
     max_pin: x.x
+    min_pin: x.x
   qt:
     max_pin: x.x
   zlib:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Checklist
 * [ ] Used a fork of the feedstock to propose changes
 * [ ] Bumped the build number (if the version is unchanged)
 * [ ] Reset the build number to `0` (if the version changed)
-* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
+* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
 * [ ] Ensured the license file is being packaged.
 
 <!--

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -54,6 +54,7 @@ cmake -LAH -G "NMake Makefiles"                                                 
     -DWITH_OPENCL=0                                                                 ^
     -DWITH_OPENNI=0                                                                 ^
     -DWITH_FFMPEG=1                                                                 ^
+    -DWITH_GSTREAMER=0                                                              ^
     -DWITH_VTK=0                                                                    ^
     -DWITH_QT=5                                                                     ^
     -DINSTALL_C_EXAMPLES=0                                                          ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -76,6 +76,7 @@ cmake -LAH                                                                \
     -DWITH_OPENCL=0                                                       \
     -DWITH_OPENNI=0                                                       \
     -DWITH_FFMPEG=1                                                       \
+    -DWITH_GSTREAMER=0                                                    \
     -DWITH_MATLAB=0                                                       \
     -DWITH_VTK=0                                                          \
     -DWITH_QT=$QT                                                         \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,11 +11,11 @@ source:
   sha256: f1b87684d75496a1054405ae3ee0b6573acaf3dad39eaf4f1d66fdd7e03dc852
 
 build:
-  number: 200
+  number: 201
   # Python2.7 support dropped: https://github.com/opencv/opencv/issues/8481
   skip: true  # [win and py27]
-  features:                    # [not win]
-    - blas_{{ blas_variant }}  # [not win]
+  features:                        # [not win]
+    - blas_{{ blas_variant }}      # [not win]
 
 requirements:
   build:
@@ -32,9 +32,9 @@ requirements:
     # For applying patches
     - git                          # [win]
     - numpy
-    - hdf5                # [unix]
+    - hdf5                         # [unix]
     - eigen 3.2.*
-    - jasper 1.900.1                       # [unix]
+    - jasper 1.900.1               # [unix]
     - zlib
     - jpeg
     - libtiff
@@ -49,8 +49,8 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - hdf5                # [unix]
-    - jasper 1.900.1                       # [unix]
+    - hdf5                         # [unix]
+    - jasper 1.900.1               # [unix]
     - zlib
     - jpeg
     - libwebp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - numpy
     - hdf5                         # [unix]
     - eigen 3.2.*
-    - jasper 1.900.1               # [unix]
+    - jasper                       # [unix]
     - zlib
     - jpeg
     - libtiff
@@ -50,7 +50,7 @@ requirements:
     - python
     - {{ pin_compatible('numpy') }}
     - hdf5                         # [unix]
-    - jasper 1.900.1               # [unix]
+    - jasper                       # [unix]
     - zlib
     - jpeg
     - libwebp


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
OpenCV VideoCapture supports many backends. Because gstreamer is indirectly brought into the build environment by the QT dependence on unix, this opencv is built thinking the gstreamer backend is available. Conda-forge only has gstreamer and gst-plugins-base, making the apparent backend actually non-functional. To avoid our build of opencv to think gstreamer is available, this PR explicitly marks its as off in cmake.