### PR TITLE
[WIP] variants for opencv: noqt

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,10 +9,16 @@ environment:
     secure: tumuXLL8PU75WMnRDemRy02ruEq2RpNxeK3dz0MjFssnosPm2v4EFjfNB4PTotA1
 
   matrix:
-    - CONFIG: win_c_compilervs2015cxx_compilervs2015python3.5
+    - CONFIG: win_c_compilervs2015cxx_compilervs2015opencv_variantnoqtpython3.5variant_version0.0.0
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
-    - CONFIG: win_c_compilervs2015cxx_compilervs2015python3.6
+    - CONFIG: win_c_compilervs2015cxx_compilervs2015opencv_variantnoqtpython3.6variant_version0.0.0
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
+
+    - CONFIG: win_c_compilervs2015cxx_compilervs2015opencv_variantwithqtpython3.5variant_version1.0.0
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
+
+    - CONFIG: win_c_compilervs2015cxx_compilervs2015opencv_variantwithqtpython3.6variant_version1.0.0
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 

--- a/.ci_support/linux_opencv_variantnoqtpython2.7variant_version0.0.0.yaml
+++ b/.ci_support/linux_opencv_variantnoqtpython2.7variant_version0.0.0.yaml
@@ -1,11 +1,21 @@
 c_compiler:
-- vs2015
+- toolchain_c
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2015
+- toolchain_cxx
+docker_image:
+- condaforge/linux-anvil
+ffmpeg:
+- '4.0'
+harfbuzz:
+- '1'
+hdf5:
+- 1.10.3
+jasper:
+- 1.900.1
 jpeg:
 - '9'
 libpng:
@@ -15,8 +25,20 @@ libtiff:
 libwebp:
 - '0.5'
 numpy:
-- '1.11'
+- '1.9'
+openblas:
+- 0.2.20
+opencv_variant:
+- noqt
 pin_run_as_build:
+  ffmpeg:
+    max_pin: x.x
+  harfbuzz:
+    max_pin: x
+  hdf5:
+    max_pin: x.x.x
+  jasper:
+    max_pin: x
   jpeg:
     max_pin: x
   libpng:
@@ -25,6 +47,8 @@ pin_run_as_build:
     max_pin: x
   libwebp:
     max_pin: x.x
+  openblas:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x
@@ -33,12 +57,13 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.6'
+- '2.7'
 qt:
 - '5.6'
+variant_version:
+- 0.0.0
 zip_keys:
-- - python
-  - c_compiler
-  - cxx_compiler
+- - variant_version
+  - opencv_variant
 zlib:
 - '1.2'

--- a/.ci_support/linux_opencv_variantnoqtpython3.5variant_version0.0.0.yaml
+++ b/.ci_support/linux_opencv_variantnoqtpython3.5variant_version0.0.0.yaml
@@ -1,5 +1,3 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
 - toolchain_c
 channel_sources:
@@ -8,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - toolchain_cxx
+docker_image:
+- condaforge/linux-anvil
 ffmpeg:
 - '4.0'
 harfbuzz:
@@ -24,10 +24,6 @@ libtiff:
 - 4.0.9
 libwebp:
 - '0.5'
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 numpy:
 - '1.9'
 openblas:
@@ -56,10 +52,14 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  qt:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:
 - '3.5'
+qt:
+- '5.6'
 variant_version:
 - 0.0.0
 zip_keys:

--- a/.ci_support/linux_opencv_variantnoqtpython3.6variant_version0.0.0.yaml
+++ b/.ci_support/linux_opencv_variantnoqtpython3.6variant_version0.0.0.yaml
@@ -13,7 +13,7 @@ ffmpeg:
 harfbuzz:
 - '1'
 hdf5:
-- 1.10.2
+- 1.10.3
 jasper:
 - 1.900.1
 jpeg:
@@ -28,6 +28,8 @@ numpy:
 - '1.9'
 openblas:
 - 0.2.20
+opencv_variant:
+- noqt
 pin_run_as_build:
   ffmpeg:
     max_pin: x.x
@@ -55,8 +57,13 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.5'
+- '3.6'
 qt:
 - '5.6'
+variant_version:
+- 0.0.0
+zip_keys:
+- - variant_version
+  - opencv_variant
 zlib:
 - '1.2'

--- a/.ci_support/linux_opencv_variantwithqtpython2.7variant_version1.0.0.yaml
+++ b/.ci_support/linux_opencv_variantwithqtpython2.7variant_version1.0.0.yaml
@@ -13,7 +13,7 @@ ffmpeg:
 harfbuzz:
 - '1'
 hdf5:
-- 1.10.2
+- 1.10.3
 jasper:
 - 1.900.1
 jpeg:
@@ -28,6 +28,8 @@ numpy:
 - '1.9'
 openblas:
 - 0.2.20
+opencv_variant:
+- withqt
 pin_run_as_build:
   ffmpeg:
     max_pin: x.x
@@ -58,5 +60,10 @@ python:
 - '2.7'
 qt:
 - '5.6'
+variant_version:
+- 1.0.0
+zip_keys:
+- - variant_version
+  - opencv_variant
 zlib:
 - '1.2'

--- a/.ci_support/linux_opencv_variantwithqtpython3.5variant_version1.0.0.yaml
+++ b/.ci_support/linux_opencv_variantwithqtpython3.5variant_version1.0.0.yaml
@@ -1,5 +1,3 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
 - toolchain_c
 channel_sources:
@@ -8,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - toolchain_cxx
+docker_image:
+- condaforge/linux-anvil
 ffmpeg:
 - '4.0'
 harfbuzz:
@@ -24,16 +24,12 @@ libtiff:
 - 4.0.9
 libwebp:
 - '0.5'
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 numpy:
 - '1.9'
 openblas:
 - 0.2.20
 opencv_variant:
-- noqt
+- withqt
 pin_run_as_build:
   ffmpeg:
     max_pin: x.x
@@ -56,12 +52,16 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  qt:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:
 - '3.5'
+qt:
+- '5.6'
 variant_version:
-- 0.0.0
+- 1.0.0
 zip_keys:
 - - variant_version
   - opencv_variant

--- a/.ci_support/linux_opencv_variantwithqtpython3.6variant_version1.0.0.yaml
+++ b/.ci_support/linux_opencv_variantwithqtpython3.6variant_version1.0.0.yaml
@@ -13,7 +13,7 @@ ffmpeg:
 harfbuzz:
 - '1'
 hdf5:
-- 1.10.2
+- 1.10.3
 jasper:
 - 1.900.1
 jpeg:
@@ -28,6 +28,8 @@ numpy:
 - '1.9'
 openblas:
 - 0.2.20
+opencv_variant:
+- withqt
 pin_run_as_build:
   ffmpeg:
     max_pin: x.x
@@ -58,5 +60,10 @@ python:
 - '3.6'
 qt:
 - '5.6'
+variant_version:
+- 1.0.0
+zip_keys:
+- - variant_version
+  - opencv_variant
 zlib:
 - '1.2'

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -13,7 +13,7 @@ ffmpeg:
 harfbuzz:
 - '1'
 hdf5:
-- 1.10.2
+- 1.10.3
 jasper:
 - 1.900.1
 jpeg:
@@ -32,6 +32,8 @@ numpy:
 - '1.9'
 openblas:
 - 0.2.20
+opencv_variant:
+- noqt
 pin_run_as_build:
   ffmpeg:
     max_pin: x.x
@@ -58,5 +60,10 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - '2.7'
+variant_version:
+- 0.0.0
+zip_keys:
+- - variant_version
+  - opencv_variant
 zlib:
 - '1.2'

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -13,7 +13,7 @@ ffmpeg:
 harfbuzz:
 - '1'
 hdf5:
-- 1.10.2
+- 1.10.3
 jasper:
 - 1.900.1
 jpeg:
@@ -32,6 +32,8 @@ numpy:
 - '1.9'
 openblas:
 - 0.2.20
+opencv_variant:
+- noqt
 pin_run_as_build:
   ffmpeg:
     max_pin: x.x
@@ -58,5 +60,10 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - '3.6'
+variant_version:
+- 0.0.0
+zip_keys:
+- - variant_version
+  - opencv_variant
 zlib:
 - '1.2'

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015opencv_variantnoqtpython3.5variant_version0.0.0.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015opencv_variantnoqtpython3.5variant_version0.0.0.yaml
@@ -1,21 +1,11 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- toolchain_c
+- vs2015
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- toolchain_cxx
-ffmpeg:
-- '4.0'
-harfbuzz:
-- '1'
-hdf5:
-- 1.10.3
-jasper:
-- 1.900.1
+- vs2015
 jpeg:
 - '9'
 libpng:
@@ -24,25 +14,11 @@ libtiff:
 - 4.0.9
 libwebp:
 - '0.5'
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 numpy:
-- '1.9'
-openblas:
-- 0.2.20
+- '1.11'
 opencv_variant:
 - noqt
 pin_run_as_build:
-  ffmpeg:
-    max_pin: x.x
-  harfbuzz:
-    max_pin: x
-  hdf5:
-    max_pin: x.x.x
-  jasper:
-    max_pin: x
   jpeg:
     max_pin: x
   libpng:
@@ -51,18 +27,23 @@ pin_run_as_build:
     max_pin: x
   libwebp:
     max_pin: x.x
-  openblas:
-    max_pin: x.x.x
   python:
     min_pin: x.x
+    max_pin: x.x
+  qt:
     max_pin: x.x
   zlib:
     max_pin: x.x
 python:
 - '3.5'
+qt:
+- '5.6'
 variant_version:
 - 0.0.0
 zip_keys:
+- - python
+  - c_compiler
+  - cxx_compiler
 - - variant_version
   - opencv_variant
 zlib:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015opencv_variantnoqtpython3.6variant_version0.0.0.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015opencv_variantnoqtpython3.6variant_version0.0.0.yaml
@@ -16,6 +16,8 @@ libwebp:
 - '0.5'
 numpy:
 - '1.11'
+opencv_variant:
+- noqt
 pin_run_as_build:
   jpeg:
     max_pin: x
@@ -33,12 +35,16 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.5'
+- '3.6'
 qt:
 - '5.6'
+variant_version:
+- 0.0.0
 zip_keys:
 - - python
   - c_compiler
   - cxx_compiler
+- - variant_version
+  - opencv_variant
 zlib:
 - '1.2'

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015opencv_variantwithqtpython3.5variant_version1.0.0.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015opencv_variantwithqtpython3.5variant_version1.0.0.yaml
@@ -1,21 +1,11 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- toolchain_c
+- vs2015
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- toolchain_cxx
-ffmpeg:
-- '4.0'
-harfbuzz:
-- '1'
-hdf5:
-- 1.10.3
-jasper:
-- 1.900.1
+- vs2015
 jpeg:
 - '9'
 libpng:
@@ -24,25 +14,11 @@ libtiff:
 - 4.0.9
 libwebp:
 - '0.5'
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 numpy:
-- '1.9'
-openblas:
-- 0.2.20
+- '1.11'
 opencv_variant:
-- noqt
+- withqt
 pin_run_as_build:
-  ffmpeg:
-    max_pin: x.x
-  harfbuzz:
-    max_pin: x
-  hdf5:
-    max_pin: x.x.x
-  jasper:
-    max_pin: x
   jpeg:
     max_pin: x
   libpng:
@@ -51,18 +27,23 @@ pin_run_as_build:
     max_pin: x
   libwebp:
     max_pin: x.x
-  openblas:
-    max_pin: x.x.x
   python:
     min_pin: x.x
+    max_pin: x.x
+  qt:
     max_pin: x.x
   zlib:
     max_pin: x.x
 python:
 - '3.5'
+qt:
+- '5.6'
 variant_version:
-- 0.0.0
+- 1.0.0
 zip_keys:
+- - python
+  - c_compiler
+  - cxx_compiler
 - - variant_version
   - opencv_variant
 zlib:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015opencv_variantwithqtpython3.6variant_version1.0.0.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015opencv_variantwithqtpython3.6variant_version1.0.0.yaml
@@ -1,21 +1,11 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- toolchain_c
+- vs2015
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- toolchain_cxx
-ffmpeg:
-- '4.0'
-harfbuzz:
-- '1'
-hdf5:
-- 1.10.3
-jasper:
-- 1.900.1
+- vs2015
 jpeg:
 - '9'
 libpng:
@@ -24,25 +14,11 @@ libtiff:
 - 4.0.9
 libwebp:
 - '0.5'
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 numpy:
-- '1.9'
-openblas:
-- 0.2.20
+- '1.11'
 opencv_variant:
-- noqt
+- withqt
 pin_run_as_build:
-  ffmpeg:
-    max_pin: x.x
-  harfbuzz:
-    max_pin: x
-  hdf5:
-    max_pin: x.x.x
-  jasper:
-    max_pin: x
   jpeg:
     max_pin: x
   libpng:
@@ -51,18 +27,23 @@ pin_run_as_build:
     max_pin: x
   libwebp:
     max_pin: x.x
-  openblas:
-    max_pin: x.x.x
   python:
     min_pin: x.x
+    max_pin: x.x
+  qt:
     max_pin: x.x
   zlib:
     max_pin: x.x
 python:
-- '3.5'
+- '3.6'
+qt:
+- '5.6'
 variant_version:
-- 0.0.0
+- 1.0.0
 zip_keys:
+- - python
+  - c_compiler
+  - cxx_compiler
 - - variant_version
   - opencv_variant
 zlib:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2
 
 jobs:
-  build_linux_python2.7:
+  build_linux_opencv_variantnoqtpython2.7variant_version0.0.0:
     working_directory: ~/test
     machine: true
     environment:
-      - CONFIG: "linux_python2.7"
+      - CONFIG: "linux_opencv_variantnoqtpython2.7variant_version0.0.0"
     steps:
       - checkout
       - run:
@@ -18,11 +18,11 @@ jobs:
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./.circleci/run_docker_build.sh
-  build_linux_python3.5:
+  build_linux_opencv_variantnoqtpython3.5variant_version0.0.0:
     working_directory: ~/test
     machine: true
     environment:
-      - CONFIG: "linux_python3.5"
+      - CONFIG: "linux_opencv_variantnoqtpython3.5variant_version0.0.0"
     steps:
       - checkout
       - run:
@@ -35,11 +35,62 @@ jobs:
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./.circleci/run_docker_build.sh
-  build_linux_python3.6:
+  build_linux_opencv_variantnoqtpython3.6variant_version0.0.0:
     working_directory: ~/test
     machine: true
     environment:
-      - CONFIG: "linux_python3.6"
+      - CONFIG: "linux_opencv_variantnoqtpython3.6variant_version0.0.0"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_opencv_variantwithqtpython2.7variant_version1.0.0:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_opencv_variantwithqtpython2.7variant_version1.0.0"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_opencv_variantwithqtpython3.5variant_version1.0.0:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_opencv_variantwithqtpython3.5variant_version1.0.0"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_opencv_variantwithqtpython3.6variant_version1.0.0:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_opencv_variantwithqtpython3.6variant_version1.0.0"
     steps:
       - checkout
       - run:
@@ -57,6 +108,9 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build_linux_python2.7
-      - build_linux_python3.5
-      - build_linux_python3.6
+      - build_linux_opencv_variantnoqtpython2.7variant_version0.0.0
+      - build_linux_opencv_variantnoqtpython3.5variant_version0.0.0
+      - build_linux_opencv_variantnoqtpython3.6variant_version0.0.0
+      - build_linux_opencv_variantwithqtpython2.7variant_version1.0.0
+      - build_linux_opencv_variantwithqtpython3.5variant_version1.0.0
+      - build_linux_opencv_variantwithqtpython3.6variant_version1.0.0

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 About opencv
 ============
 
-Home: http://opencv.org/
+Home: 
 
-Package license: BSD 3-clause
+Package license: 
 
 Feedstock license: BSD 3-Clause
 
-Summary: Computer vision and machine learning software library.
+Summary: A package to specify the default opencv variant.
 
 
 
@@ -23,7 +23,10 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-_opencv_variant-green.svg)](https://anaconda.org/conda-forge/_opencv_variant) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/_opencv_variant.svg)](https://anaconda.org/conda-forge/_opencv_variant) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/_opencv_variant.svg)](https://anaconda.org/conda-forge/_opencv_variant) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/_opencv_variant.svg)](https://anaconda.org/conda-forge/_opencv_variant) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-opencv-green.svg)](https://anaconda.org/conda-forge/opencv) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/opencv.svg)](https://anaconda.org/conda-forge/opencv) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/opencv.svg)](https://anaconda.org/conda-forge/opencv) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/opencv.svg)](https://anaconda.org/conda-forge/opencv) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-opencv--noqt-green.svg)](https://anaconda.org/conda-forge/opencv-noqt) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/opencv-noqt.svg)](https://anaconda.org/conda-forge/opencv-noqt) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/opencv-noqt.svg)](https://anaconda.org/conda-forge/opencv-noqt) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/opencv-noqt.svg)](https://anaconda.org/conda-forge/opencv-noqt) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-opencv--withqt-green.svg)](https://anaconda.org/conda-forge/opencv-withqt) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/opencv-withqt.svg)](https://anaconda.org/conda-forge/opencv-withqt) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/opencv-withqt.svg)](https://anaconda.org/conda-forge/opencv-withqt) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/opencv-withqt.svg)](https://anaconda.org/conda-forge/opencv-withqt) |
 
 Installing opencv
 =================
@@ -34,16 +37,16 @@ Installing `opencv` from the `conda-forge` channel can be achieved by adding `co
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `opencv` can be installed with:
+Once the `conda-forge` channel has been enabled, `_opencv_variant, opencv, opencv-noqt, opencv-withqt` can be installed with:
 
 ```
-conda install opencv
+conda install _opencv_variant opencv opencv-noqt opencv-withqt
 ```
 
-It is possible to list all of the versions of `opencv` available on your platform with:
+It is possible to list all of the versions of `_opencv_variant` available on your platform with:
 
 ```
-conda search opencv --channel conda-forge
+conda search _opencv_variant --channel conda-forge
 ```
 
 

--- a/recipe/build_opencv.bat
+++ b/recipe/build_opencv.bat
@@ -1,6 +1,12 @@
 @echo ON
-setlocal enabledelayedexpansion
 
+if "%opencv_variant%" == "noqt" (
+    set QT=0
+) else (
+    set QT=5
+)
+
+setlocal enabledelayedexpansion
 
 if "%PY3K%" == "0" (
     echo "Copying stdint.h for windows"
@@ -49,7 +55,7 @@ cmake -LAH -G "NMake Makefiles"                                                 
     -DWITH_FFMPEG=1                                                                 ^
     -DWITH_GSTREAMER=0                                                              ^
     -DWITH_VTK=0                                                                    ^
-    -DWITH_QT=5                                                                     ^
+    -DWITH_QT=%QT%                                                                  ^
     -DINSTALL_C_EXAMPLES=0                                                          ^
     -DOPENCV_EXTRA_MODULES_PATH=%UNIX_SRC_DIR%/opencv_contrib/modules               ^
     -DEXECUTABLE_OUTPUT_PATH=%UNIX_LIBRARY_BIN%                                     ^

--- a/recipe/build_opencv.sh
+++ b/recipe/build_opencv.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
+set -x
 
-set +x
+if [ "$opencv_variant" == "noqt" ]; then
+    QT=0
+else
+    QT=5
+fi
+
 SHORT_OS_STR=$(uname -s)
 
-QT="5"
 if [ "${SHORT_OS_STR:0:5}" == "Linux" ]; then
     OPENMP="-DWITH_OPENMP=1"
     # Looks like there's a bug in Opencv 3.2.0 for building with FFMPEG
@@ -12,7 +17,6 @@ if [ "${SHORT_OS_STR:0:5}" == "Linux" ]; then
 fi
 if [ "${SHORT_OS_STR}" == "Darwin" ]; then
     OPENMP=""
-    QT="0"
 fi
 
 mkdir -p build

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,9 @@
+variant_version:
+  - "1.0.0"  # [not osx]
+  - "0.0.0"
+opencv_variant:
+  - "withqt"  # [not osx]
+  - "noqt"
+zip_keys:
+  - variant_version
+  - opencv_variant

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,9 @@
 {% set version = "3.4.3" %}
+{% set name = "opencv" %}
 {% set blas_variant = "openblas" %}
 
 package:
-  name: opencv
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
@@ -23,49 +24,14 @@ build:
   number: 200
   # Python2.7 support dropped: https://github.com/opencv/opencv/issues/8481
   skip: true  # [win and py27]
-  features:                        # [not win]
-    - blas_{{ blas_variant }}      # [not win]
 
 requirements:
+  # build needs python so as to create different packges per python
   build:
-    # Required to find ffpmeg
-    - pkg-config                   # [not win]
     - m2-patch                     # [win]
-    - cmake
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-  host:
     - python
-    - numpy
-    - hdf5                         # [unix]
-    - eigen 3.2.*
-    - jasper                       # [unix]
-    - zlib
-    - jpeg
-    - libtiff
-    - libwebp
-    - harfbuzz                     # [unix]
-    - libpng
-    - openblas                     # [not win]
-    - blas 1.1 {{ blas_variant }}  # [not win]
-    - ffmpeg                       # [not win]
-    - qt                           # [not osx]
-
   run:
-    - python
-    - {{ pin_compatible('numpy') }}
-    - hdf5                         # [unix]
-    - jasper                       # [unix]
-    - zlib
-    - jpeg
-    - libwebp
-    - harfbuzz                     # [unix]
-    - libtiff
-    - libpng
-    - openblas                     # [not win]
-    - blas 1.1 {{ blas_variant }}  # [not win]
-    - ffmpeg                       # [not win]
-    - qt                           # [not osx]
+    - {{ pin_subpackage(name|lower + '-' + opencv_variant, exact=True) }}
 
 test:
     requires:
@@ -128,13 +94,76 @@ test:
         - test -f $PREFIX/lib/libopencv_hdf${SHLIB_EXT}          # [unix]
         - test -f $PREFIX/lib/libopencv_freetype${SHLIB_EXT}     # [unix]
 
+outputs:
+  - name: _opencv_variant
+    version: {{ variant_version }}
+    build:
+      string: {{ opencv_variant }}
+    about:
+      summary: "A package to specify the default opencv variant."
+
+  - name: {{ name + '-' + opencv_variant }}
+    build:
+      features:                    # [not win]
+        - blas_{{ blas_variant }}  # [not win]
+      script:
+        - "%RECIPE_DIR%\\build_opencv.bat"    # [win]
+        - bash $RECIPE_DIR/build_opencv.sh    # [not win]
+    requirements:
+      build:
+        - openssl 1.0.*                # [unix]
+        - curl >=7.44.0,<8
+        - cmake
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        # required to find ffpmeg
+        - pkg-config                   # [unix]
+      host:
+        - python
+        - numpy
+        - hdf5                         # [unix]
+        - eigen 3.2.*
+        - jasper                       # [unix]
+        - zlib
+        - jpeg
+        - libtiff
+        - libwebp
+        - harfbuzz                     # [unix]
+        - libpng
+        - openblas                     # [not win]
+        - blas 1.1 {{ blas_variant }}  # [not win]
+        - ffmpeg                       # [not win]
+        - qt                           # [opencv_variant == 'withqt']
+      run:
+        - python
+        - {{ pin_compatible('numpy') }}
+        - hdf5                         # [unix]
+        - jasper                       # [unix]
+        - zlib
+        - jpeg
+        - libwebp
+        - harfbuzz                     # [unix]
+        - libtiff
+        - libpng
+        - openblas                     # [not win]
+        - blas 1.1 {{ blas_variant }}  # [not win]
+        - ffmpeg                       # [not win]
+        - qt                           # [opencv_variant == 'withqt']
+        - {{ pin_subpackage( "_opencv_variant", exact=True) }}
+    extra:
+      opencv_variant: {{ opencv_variant }}
+
+
 about:
   home: http://opencv.org/
   license: BSD 3-clause
-  summary: Computer vision and machine learning software library.
+  summary: Computer vision and machine learning software library compiled with Qt5.     # [opencv_variant == 'withqt']
+  summary: Computer vision and machine learning software library compiled without Qt5.  # [opencv_variant == 'noqt']
   license_file: LICENSE
 
+
 extra:
+  opencv_variant: {{ opencv_variant }}
   recipe-maintainers:
     - jakirkham
     - msarahan


### PR DESCRIPTION
I'm working on adding infrastructure to this recipe that would allow for opencv variants.

Right now, it is at the: works on my machine (maybe kinda sorta).
I think we can use variations of this idea to implement a split package for python.


Actually useful feature:
- Added the opencv_contrib as an additional source in the meta.yaml allowing it to be cached on your computer.


Compiles on:
With QT
- [x] Linux
- [x] Windows

Without QT
- [ ] Linux
- [x] Windows
- [x] Mac

Passes tests With QT
- [x] Linux
- [x] Windows 

Passes tests without QT
- [x] Linux
- [x] Windows
- [x] Mac

Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
