### PR TITLE
Use Ninja

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -28,7 +28,7 @@ set UNIX_LIBRARY_LIB=%LIBRARY_LIB:\=/%
 set UNIX_SP_DIR=%SP_DIR:\=/%
 set UNIX_SRC_DIR=%SRC_DIR:\=/%
 
-cmake -LAH -G "NMake Makefiles"                                                     ^
+cmake -LAH -G "Ninja"                                                               ^
     -DCMAKE_BUILD_TYPE="Release"                                                    ^
     -DCMAKE_INSTALL_PREFIX=%UNIX_LIBRARY_PREFIX%                                    ^
     -DCMAKE_PREFIX_PATH=%UNIX_LIBRARY_PREFIX%                                       ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -83,7 +83,7 @@ cmake -LAH -G "Ninja"                                                           
     ..
 if errorlevel 1 exit 1
 
-cmake --build . --target INSTALL --config Release
+cmake --build . --target install --config Release
 if errorlevel 1 exit 1
 
 if "%ARCH%" == "32" ( set "OPENCV_ARCH=86")

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -80,7 +80,7 @@ PYTHON_UNSET_INSTALL="-DOPENCV_PYTHON${PY_UNSET_MAJOR}_INSTALL_PATH=${SP_DIR}"
 # FFMPEG building requires pkgconfig
 export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$PREFIX/lib/pkgconfig
 
-cmake -LAH                                                                \
+cmake -LAH -G "Ninja"                                                     \
     -DCMAKE_BUILD_TYPE="Release"                                          \
     -DCMAKE_PREFIX_PATH=${PREFIX}                                         \
     -DCMAKE_INSTALL_PREFIX=${PREFIX}                                      \
@@ -141,4 +141,4 @@ cmake -LAH                                                                \
     $PYTHON_UNSET_INSTALL                                                 \
     ..
 
-make install -j${CPU_COUNT} VERBOSE=1
+ninja install -v

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - pkg-config                     # [not win]
     - m2-patch                       # [win]
     - cmake
+    - ninja
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ cdt('mesa-libgl-devel') }}  # [linux]
@@ -39,7 +40,6 @@ requirements:
     - {{ cdt('libxdamage') }}        # [linux]
     - {{ cdt('libxfixes') }}         # [linux]
     - {{ cdt('libxxf86vm') }}        # [linux]
-    - make                           # [unix]
   host:
     - python
     - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
       - 1905-cvv_repair_build.patch
 
 build:
-  number: 1202
+  number: 1203
   # Python2.7 support dropped: https://github.com/opencv/opencv/issues/8481
   skip: true  # [win and py27]
   features:                        # [not win]


### PR DESCRIPTION
As we have had some issues with the new compiler builds on Travis CI running out of time, this tries switching builds to use Ninja instead. Also should speed up Windows builds, which were just using NMake before.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
