### PR TITLE
Qt 5.9 again

### DIFF
--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -53,6 +53,6 @@ pin_run_as_build:
 python:
 - '2.7'
 qt:
-- '5.6'
+- '5.9'
 zlib:
 - '1.2'

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -53,6 +53,6 @@ pin_run_as_build:
 python:
 - '3.6'
 qt:
-- '5.6'
+- '5.9'
 zlib:
 - '1.2'

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -53,6 +53,6 @@ pin_run_as_build:
 python:
 - '3.7'
 qt:
-- '5.6'
+- '5.9'
 zlib:
 - '1.2'

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.yaml
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - '3.6'
 qt:
-- '5.6'
+- '5.9'
 zip_keys:
 - - python
   - c_compiler

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7.yaml
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - '3.7'
 qt:
-- '5.6'
+- '5.9'
 zip_keys:
 - - python
   - c_compiler

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     folder: opencv_contrib
 
 build:
-  number: 1
+  number: 2
   # Python2.7 support dropped: https://github.com/opencv/opencv/issues/8481
   skip: true  # [win and py27]
 


### PR DESCRIPTION
I didn't realized that qt had a pinning, and https://github.com/conda-forge/opencv-feedstock/pull/156 did not rerender with the new one.


Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
