### PR TITLE
Freetype pinning

### DIFF
--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -12,6 +12,8 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
+freetype:
+- 2.9.1
 harfbuzz:
 - '2'
 hdf5:
@@ -31,6 +33,8 @@ libwebp:
 numpy:
 - '1.14'
 pin_run_as_build:
+  freetype:
+    max_pin: x
   harfbuzz:
     max_pin: x
   jasper:

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -12,6 +12,8 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
+freetype:
+- 2.9.1
 harfbuzz:
 - '2'
 hdf5:
@@ -31,6 +33,8 @@ libwebp:
 numpy:
 - '1.14'
 pin_run_as_build:
+  freetype:
+    max_pin: x
   harfbuzz:
     max_pin: x
   jasper:

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -12,6 +12,8 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
+freetype:
+- 2.9.1
 harfbuzz:
 - '2'
 hdf5:
@@ -31,6 +33,8 @@ libwebp:
 numpy:
 - '1.14'
 pin_run_as_build:
+  freetype:
+    max_pin: x
   harfbuzz:
     max_pin: x
   jasper:

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '4'
+freetype:
+- 2.9.1
 harfbuzz:
 - '2'
 hdf5:
@@ -37,6 +39,8 @@ macos_min_version:
 numpy:
 - '1.14'
 pin_run_as_build:
+  freetype:
+    max_pin: x
   harfbuzz:
     max_pin: x
   jasper:

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '4'
+freetype:
+- 2.9.1
 harfbuzz:
 - '2'
 hdf5:
@@ -37,6 +39,8 @@ macos_min_version:
 numpy:
 - '1.14'
 pin_run_as_build:
+  freetype:
+    max_pin: x
   harfbuzz:
     max_pin: x
   jasper:

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '4'
+freetype:
+- 2.9.1
 harfbuzz:
 - '2'
 hdf5:
@@ -37,6 +39,8 @@ macos_min_version:
 numpy:
 - '1.14'
 pin_run_as_build:
+  freetype:
+    max_pin: x
   harfbuzz:
     max_pin: x
   jasper:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.yaml
@@ -6,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2015
+freetype:
+- 2.9.1
 jpeg:
 - '9'
 liblapacke:
@@ -19,6 +21,8 @@ libwebp:
 numpy:
 - '1.14'
 pin_run_as_build:
+  freetype:
+    max_pin: x
   jpeg:
     max_pin: x
   libpng:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7.yaml
@@ -6,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2015
+freetype:
+- 2.9.1
 jpeg:
 - '9'
 liblapacke:
@@ -19,6 +21,8 @@ libwebp:
 numpy:
 - '1.14'
 pin_run_as_build:
+  freetype:
+    max_pin: x
   jpeg:
     max_pin: x
   libpng:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,7 +68,8 @@ requirements:
     # https://github.com/conda-forge/opencv-feedstock/issues/174
     # Seems like the OSX ABI has changed between 2.9 and 2.10???
     # That or a dependency wasn't merged in
-    - {{ pin_compatible('freetype', min_pin='x.x') }}  # [osx]
+    # Since we don't know the cause, we are choosing this pinning on all platforms.
+    - {{ pin_compatible('freetype', min_pin='x.x') }}
 
 test:
     requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     folder: opencv_contrib
 
 build:
-  number: 0
+  number: 1
   # Python2.7 support dropped: https://github.com/opencv/opencv/issues/8481
   skip: true  # [win and py27]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,7 @@ requirements:
     - ffmpeg 4.1.*                   # [not win]
     - qt                             # [not osx]
     - liblapacke
+    - freetype
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -64,6 +65,10 @@ requirements:
     - libpng
     - ffmpeg 4.1.*                   # [not win]
     - qt                             # [not osx]
+    # https://github.com/conda-forge/opencv-feedstock/issues/174
+    # Seems like the OSX ABI has changed between 2.9 and 2.10???
+    # That or a dependency wasn't merged in
+    - {{ pin_compatible('freetype', min_pin='x.x') }}  # [osx]
 
 test:
     requires:


### PR DESCRIPTION
Fixup the pinning for OSX and freetype
https://github.com/conda-forge/opencv-feedstock/issues/174

See builds in https://github.com/conda-forge/opencv-feedstock/pull/175
that show that freetype 2.9 can be used with all platforms but osx.


Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
