### PR TITLE
[demo] Libtiff incompatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ source:
     folder: opencv_contrib
 
 build:
-  number: 0
+  number: 1
   # Python2.7 support dropped: https://github.com/opencv/opencv/issues/8481
   skip: true  # [win and py27]
   run_exports:
@@ -205,6 +205,8 @@ outputs:
         # One test done on different versions of python on each platform
         - liblapack * *openblas         # [py==36]
         - liblapack * *mkl              # [py==37]
+        - libtiff 4.1                   # [py==36]
+        - libtiff 4.0                   # [py==37]
       imports:
         - cv2
         - cv2.xfeatures2d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -101,8 +101,10 @@ test:
       - pkg-config                    # [not win]
       # Test with the two currently supported lapack implementatons
       # One test done on different versions of python on each platform
-      - liblapack * *openblas         # [py==36]
+      - liblapack * *mkl              # [py==36]
       - liblapack * *mkl              # [py==37]
+      - libtiff   4.0                 # [py==36]
+      - libtiff   4.1                 # [py==37]
       - cmake
       - ninja
       - qt 5.12.1                     # [linux]
@@ -203,10 +205,10 @@ outputs:
         - certifi
         # Test with the two currently supported lapack implementatons
         # One test done on different versions of python on each platform
-        - liblapack * *openblas         # [py==36]
+        - liblapack * *mkl              # [py==36]
         - liblapack * *mkl              # [py==37]
-        - libtiff 4.1                   # [py==36]
-        - libtiff 4.0                   # [py==37]
+        - libtiff 4.0                   # [py==36]
+        - libtiff 4.1                   # [py==37]
       imports:
         - cv2
         - cv2.xfeatures2d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,9 @@ source:
     fn: opencv_contrib-{{ version }}.tar.gz
     sha256: 0f6c3d30baa39e3e7611afb481ee86dea45dafb182cac87d570c95dccd83eb8b
     folder: opencv_contrib
+  - url: https://github.com/opencv/opencv_extra/raw/master/testdata/highgui/video/VID00003-20100701-2204.avi
+    fn: VID00003-20100701-2204.avi
+    sha256: 78884f64b564a3b06dc6ee731ed33b60c6d8cd864cea07f21d94ba0f90c7b310
 
 build:
   number: 1
@@ -201,8 +204,6 @@ outputs:
         - {{ pin_subpackage('libopencv', exact=True) }}
     test:
       requires:
-        - requests
-        - certifi
         # Test with the two currently supported lapack implementatons
         # One test done on different versions of python on each platform
         - liblapack * *mkl              # [py==36]
@@ -214,6 +215,7 @@ outputs:
         - cv2.xfeatures2d
       files:
         - run_py_test.py
+        - VID00003-20100701-2204.avi
       commands:
         - python run_py_test.py
         - if [[ $($PYTHON -c 'import cv2; print(cv2.__version__)') != $PKG_VERSION ]]; then exit 1; fi  # [unix]

--- a/recipe/run_py_test.py
+++ b/recipe/run_py_test.py
@@ -9,24 +9,13 @@ import requests
 
 import cv2
 
-OPENCV_AVI_URL = 'https://github.com/opencv/opencv_extra/raw/master/testdata/highgui/video/VID00003-20100701-2204.avi'
-
-
 @unittest.skipIf(platform.system() == 'Windows',
                  'FFMPEG currently not built on Windows')
 class TestVideoRead(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.temp_dir = tempfile.mkdtemp()
-        cls.avi_path = op.join(cls.temp_dir, 'test.avi')
-        req = requests.get(OPENCV_AVI_URL, stream=True)
-        with open(cls.avi_path, 'wb') as f:
-            shutil.copyfileobj(req.raw, f)
-
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls.avi_path, ignore_errors=True)
+        cls.avi_path = 'VID00003-20100701-2204.avi'
 
     def test_load_avi(self):
         cap = cv2.VideoCapture(self.avi_path)

--- a/recipe/run_py_test.py
+++ b/recipe/run_py_test.py
@@ -1,11 +1,7 @@
 import unittest
-import os.path as op
 import platform
-import shutil
-import tempfile
 
 import numpy as np
-import requests
 
 import cv2
 
@@ -31,7 +27,8 @@ class TestGEMM(unittest.TestCase):
         c = np.ones(sz, dtype=float)
         x = cv2.gemm(a, b, 2, c, 3)
         gold = np.full(sz, 5, dtype=float)
-        self.assertTrue(np.array_equal(gold, x), "Array returned by GEMM is not valid")
+        self.assertTrue(np.array_equal(gold, x),
+                        "Array returned by GEMM is not valid")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Pretty sure you need libtiff to be pinned to 4.0 on windows.

This has been causing me so many headaches....


https://github.com/conda-forge/opencv-feedstock/issues/196

Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
