### PR TITLE
Aarch and ppc64le (without QT)

### DIFF
--- a/.ci_support/linux_64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.6.____cpython.yaml
@@ -18,6 +18,8 @@ ffmpeg:
 - '4.3'
 freetype:
 - 2.9.1
+glib:
+- '2.58'
 harfbuzz:
 - '2'
 hdf5:

--- a/.ci_support/linux_64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.8.____cpython.yaml
@@ -18,6 +18,8 @@ ffmpeg:
 - '4.3'
 freetype:
 - 2.9.1
+glib:
+- '2.58'
 harfbuzz:
 - '2'
 hdf5:

--- a/.ci_support/linux_64_numpy1.18python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.6.____73_pypy.yaml
@@ -18,6 +18,8 @@ ffmpeg:
 - '4.3'
 freetype:
 - 2.9.1
+glib:
+- '2.58'
 harfbuzz:
 - '2'
 hdf5:

--- a/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
@@ -18,6 +18,8 @@ ffmpeg:
 - '4.3'
 freetype:
 - 2.9.1
+glib:
+- '2.58'
 harfbuzz:
 - '2'
 hdf5:

--- a/.ci_support/linux_aarch64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.16python3.6.____cpython.yaml
@@ -1,11 +1,15 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_arch:
+- aarch64
 cdt_name:
-- cos6
+- cos7
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -13,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-aarch64
 ffmpeg:
 - '4.3'
 freetype:
@@ -24,8 +28,6 @@ harfbuzz:
 - '2'
 hdf5:
 - 1.10.6
-jasper:
-- 1.900.1
 jpeg:
 - '9'
 liblapacke:
@@ -45,8 +47,6 @@ pin_run_as_build:
     max_pin: x
   harfbuzz:
     max_pin: x
-  jasper:
-    max_pin: x
   jpeg:
     max_pin: x
   libpng:
@@ -59,9 +59,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.6.* *_cpython
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.16python3.7.____cpython.yaml
@@ -1,11 +1,15 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_arch:
+- aarch64
 cdt_name:
-- cos6
+- cos7
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -13,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-aarch64
 ffmpeg:
 - '4.3'
 freetype:
@@ -24,8 +28,6 @@ harfbuzz:
 - '2'
 hdf5:
 - 1.10.6
-jasper:
-- 1.900.1
 jpeg:
 - '9'
 liblapacke:
@@ -45,8 +47,6 @@ pin_run_as_build:
     max_pin: x
   harfbuzz:
     max_pin: x
-  jasper:
-    max_pin: x
   jpeg:
     max_pin: x
   libpng:
@@ -61,7 +61,7 @@ pin_run_as_build:
 python:
 - 3.7.* *_cpython
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.16python3.8.____cpython.yaml
@@ -1,11 +1,15 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_arch:
+- aarch64
 cdt_name:
-- cos6
+- cos7
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -13,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-aarch64
 ffmpeg:
 - '4.3'
 freetype:
@@ -24,8 +28,6 @@ harfbuzz:
 - '2'
 hdf5:
 - 1.10.6
-jasper:
-- 1.900.1
 jpeg:
 - '9'
 liblapacke:
@@ -45,8 +47,6 @@ pin_run_as_build:
     max_pin: x
   harfbuzz:
     max_pin: x
-  jasper:
-    max_pin: x
   jpeg:
     max_pin: x
   libpng:
@@ -59,9 +59,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.8.* *_cpython
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_numpy1.18python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_aarch64_numpy1.18python3.6.____73_pypy.yaml
@@ -1,11 +1,15 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_arch:
+- aarch64
 cdt_name:
-- cos6
+- cos7
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -13,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-aarch64
 ffmpeg:
 - '4.3'
 freetype:
@@ -24,8 +28,6 @@ harfbuzz:
 - '2'
 hdf5:
 - 1.10.6
-jasper:
-- 1.900.1
 jpeg:
 - '9'
 liblapacke:
@@ -37,15 +39,13 @@ libtiff:
 libwebp:
 - '1.1'
 numpy:
-- '1.16'
+- '1.18'
 pin_run_as_build:
   ffmpeg:
     max_pin: x.x
   freetype:
     max_pin: x
   harfbuzz:
-    max_pin: x
-  jasper:
     max_pin: x
   jpeg:
     max_pin: x
@@ -59,9 +59,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.6.* *_73_pypy
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.9.____cpython.yaml
@@ -1,11 +1,15 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_arch:
+- aarch64
 cdt_name:
-- cos6
+- cos7
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -13,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-aarch64
 ffmpeg:
 - '4.3'
 freetype:
@@ -24,8 +28,6 @@ harfbuzz:
 - '2'
 hdf5:
 - 1.10.6
-jasper:
-- 1.900.1
 jpeg:
 - '9'
 liblapacke:
@@ -37,15 +39,13 @@ libtiff:
 libwebp:
 - '1.1'
 numpy:
-- '1.16'
+- '1.19'
 pin_run_as_build:
   ffmpeg:
     max_pin: x.x
   freetype:
     max_pin: x
   harfbuzz:
-    max_pin: x
-  jasper:
     max_pin: x
   jpeg:
     max_pin: x
@@ -59,9 +59,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.9.* *_cpython
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.16python3.6.____cpython.yaml
@@ -1,9 +1,9 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '8'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,9 +11,9 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '8'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-ppc64le
 ffmpeg:
 - '4.3'
 freetype:
@@ -24,8 +24,6 @@ harfbuzz:
 - '2'
 hdf5:
 - 1.10.6
-jasper:
-- 1.900.1
 jpeg:
 - '9'
 liblapacke:
@@ -45,8 +43,6 @@ pin_run_as_build:
     max_pin: x
   harfbuzz:
     max_pin: x
-  jasper:
-    max_pin: x
   jpeg:
     max_pin: x
   libpng:
@@ -59,9 +55,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.6.* *_cpython
 target_platform:
-- linux-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.16python3.7.____cpython.yaml
@@ -1,9 +1,9 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '8'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,9 +11,9 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '8'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-ppc64le
 ffmpeg:
 - '4.3'
 freetype:
@@ -24,8 +24,6 @@ harfbuzz:
 - '2'
 hdf5:
 - 1.10.6
-jasper:
-- 1.900.1
 jpeg:
 - '9'
 liblapacke:
@@ -45,8 +43,6 @@ pin_run_as_build:
     max_pin: x
   harfbuzz:
     max_pin: x
-  jasper:
-    max_pin: x
   jpeg:
     max_pin: x
   libpng:
@@ -61,7 +57,7 @@ pin_run_as_build:
 python:
 - 3.7.* *_cpython
 target_platform:
-- linux-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.16python3.8.____cpython.yaml
@@ -1,9 +1,9 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '8'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,9 +11,9 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '8'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-ppc64le
 ffmpeg:
 - '4.3'
 freetype:
@@ -24,8 +24,6 @@ harfbuzz:
 - '2'
 hdf5:
 - 1.10.6
-jasper:
-- 1.900.1
 jpeg:
 - '9'
 liblapacke:
@@ -45,8 +43,6 @@ pin_run_as_build:
     max_pin: x
   harfbuzz:
     max_pin: x
-  jasper:
-    max_pin: x
   jpeg:
     max_pin: x
   libpng:
@@ -59,9 +55,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.8.* *_cpython
 target_platform:
-- linux-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_numpy1.18python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.18python3.6.____73_pypy.yaml
@@ -1,9 +1,9 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '8'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,9 +11,9 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '8'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-ppc64le
 ffmpeg:
 - '4.3'
 freetype:
@@ -24,8 +24,6 @@ harfbuzz:
 - '2'
 hdf5:
 - 1.10.6
-jasper:
-- 1.900.1
 jpeg:
 - '9'
 liblapacke:
@@ -37,15 +35,13 @@ libtiff:
 libwebp:
 - '1.1'
 numpy:
-- '1.16'
+- '1.18'
 pin_run_as_build:
   ffmpeg:
     max_pin: x.x
   freetype:
     max_pin: x
   harfbuzz:
-    max_pin: x
-  jasper:
     max_pin: x
   jpeg:
     max_pin: x
@@ -59,9 +55,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.6.* *_73_pypy
 target_platform:
-- linux-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.19python3.9.____cpython.yaml
@@ -1,9 +1,9 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '8'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,9 +11,9 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '8'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-ppc64le
 ffmpeg:
 - '4.3'
 freetype:
@@ -24,8 +24,6 @@ harfbuzz:
 - '2'
 hdf5:
 - 1.10.6
-jasper:
-- 1.900.1
 jpeg:
 - '9'
 liblapacke:
@@ -37,15 +35,13 @@ libtiff:
 libwebp:
 - '1.1'
 numpy:
-- '1.16'
+- '1.19'
 pin_run_as_build:
   ffmpeg:
     max_pin: x.x
   freetype:
     max_pin: x
   harfbuzz:
-    max_pin: x
-  jasper:
     max_pin: x
   jpeg:
     max_pin: x
@@ -59,9 +55,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.9.* *_cpython
 target_platform:
-- linux-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.6.____cpython.yaml
@@ -16,6 +16,8 @@ ffmpeg:
 - '4.3'
 freetype:
 - 2.9.1
+glib:
+- '2.58'
 harfbuzz:
 - '2'
 hdf5:

--- a/.ci_support/osx_64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.7.____cpython.yaml
@@ -16,6 +16,8 @@ ffmpeg:
 - '4.3'
 freetype:
 - 2.9.1
+glib:
+- '2.58'
 harfbuzz:
 - '2'
 hdf5:

--- a/.ci_support/osx_64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ ffmpeg:
 - '4.3'
 freetype:
 - 2.9.1
+glib:
+- '2.58'
 harfbuzz:
 - '2'
 hdf5:

--- a/.ci_support/osx_64_numpy1.18python3.6.____73_pypy.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.6.____73_pypy.yaml
@@ -16,6 +16,8 @@ ffmpeg:
 - '4.3'
 freetype:
 - 2.9.1
+glib:
+- '2.58'
 harfbuzz:
 - '2'
 hdf5:

--- a/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ ffmpeg:
 - '4.3'
 freetype:
 - 2.9.1
+glib:
+- '2.58'
 harfbuzz:
 - '2'
 hdf5:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,155 @@
+---
+kind: pipeline
+name: linux_aarch64_numpy1.16python3.6.____cpython
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_numpy1.16python3.6.____cpython
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+
+---
+kind: pipeline
+name: linux_aarch64_numpy1.16python3.7.____cpython
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_numpy1.16python3.7.____cpython
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+
+---
+kind: pipeline
+name: linux_aarch64_numpy1.16python3.8.____cpython
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_numpy1.16python3.8.____cpython
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+
+---
+kind: pipeline
+name: linux_aarch64_numpy1.18python3.6.____73_pypy
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_numpy1.18python3.6.____73_pypy
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+
+---
+kind: pipeline
+name: linux_aarch64_numpy1.19python3.9.____cpython
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_numpy1.19python3.9.____cpython
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+
+language: generic
+
+
+
+matrix:
+  include:
+    - env: CONFIG=linux_ppc64le_numpy1.16python3.6.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+    - env: CONFIG=linux_ppc64le_numpy1.16python3.7.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+    - env: CONFIG=linux_ppc64le_numpy1.16python3.8.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+    - env: CONFIG=linux_ppc64le_numpy1.18python3.6.____73_pypy UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+    - env: CONFIG=linux_ppc64le_numpy1.19python3.9.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+script:
+  - export CI=travis
+  - export GIT_BRANCH="$TRAVIS_BRANCH"
+  - export FEEDSTOCK_NAME=$(basename ${TRAVIS_REPO_SLUG})
+
+
+  - if [[ ${PLATFORM} =~ .*linux.* ]]; then ./.scripts/run_docker_build.sh; fi

--- a/README.md
+++ b/README.md
@@ -13,7 +13,21 @@ Current build status
 ====================
 
 
-<table>
+<table><tr>
+    <td>Travis</td>
+    <td>
+      <a href="https://travis-ci.com/conda-forge/opencv-feedstock">
+        <img alt="macOS" src="https://img.shields.io/travis/com/conda-forge/opencv-feedstock/master.svg?label=macOS">
+      </a>
+    </td>
+  </tr><tr>
+    <td>Drone</td>
+    <td>
+      <a href="https://cloud.drone.io/conda-forge/opencv-feedstock">
+        <img alt="linux" src="https://img.shields.io/drone/build/conda-forge/opencv-feedstock/master.svg?label=Linux">
+      </a>
+    </td>
+  </tr>
     
   <tr>
     <td>Azure</td>
@@ -59,6 +73,76 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.19python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.16python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.16python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.16python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.16python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.16python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.16python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.18python3.6.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.18python3.6.____73_pypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.19python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.19python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_numpy1.16python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.16python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_numpy1.16python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.16python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_numpy1.16python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.16python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_numpy1.18python3.6.____73_pypy</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.18python3.6.____73_pypy" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_numpy1.19python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.19python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,5 @@
 provider:
   win: azure
 conda_forge_output_validation: true
+provider: {linux_aarch64: default, linux_ppc64le: default}
+

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -54,7 +54,7 @@ cmake -LAH -G "Ninja"                                                           
     -DBUILD_TIFF=0                                                                  ^
     -DBUILD_PNG=0                                                                   ^
     -DBUILD_OPENEXR=1                                                               ^
-    -DBUILD_JASPER=1                                                                ^
+    -DBUILD_JASPER=0                                                                ^
     -DWITH_JASPER=1                                                                 ^
     -DWITH_OPENJPEG=0                                                               ^
     -DBUILD_JPEG=0                                                                  ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,7 +10,6 @@ ln -s $PREFIX/include/libpng16 $PREFIX/include/libpng
 
 QT="5"
 V4L="1"
-JASPER="1"
 
 if [ "${SHORT_OS_STR:0:5}" == "Linux" ]; then
     OPENMP="-DWITH_OPENMP=1"
@@ -41,7 +40,6 @@ if [ "${MACHINE_STR}" == "aarch64" ] || [ "${MACHINE_STR:0:3}" == "arm" ] || [ "
     echo Building aarch or ppc
     OPENMP="-DWITH_OPENMP=1"
     QT="0"
-    JASPER="0"
 fi
 
 CMAKE_TOOLCHAIN_CMD_FLAGS=""
@@ -128,7 +126,7 @@ cmake -LAH -G "Ninja"                                                     \
     -DBUILD_PNG=0                                                         \
     -DBUILD_OPENEXR=1                                                     \
     -DBUILD_JASPER=0                                                      \
-    -DWITH_JASPER=$JASPER                                                 \
+    -DWITH_JASPER=1                                                       \
     -DWITH_OPENJPEG=0                                                     \
     -DBUILD_JPEG=0                                                        \
     -DWITH_V4L=$V4L                                                       \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -175,4 +175,8 @@ cmake -LAH -G "Ninja"                                                     \
     $PYTHON_UNSET_INSTALL                                                 \
     ..
 
-ninja install -v
+if [ "${MACHINE_STR:0:3}" == "ppc" ]; then 
+    # PPC seems to run out of memory quite often, build with fewer jobs.
+    NINJA_OPTS=-j2
+fi
+ninja install -v ${NINJA_OPTS}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -37,8 +37,6 @@ if [ "${SHORT_OS_STR}" == "Darwin" ]; then
 fi
 
 if [ "${MACHINE_STR}" == "aarch64" ] || [ "${MACHINE_STR:0:3}" == "arm" ] || [ "${MACHINE_STR:0:3}" == "ppc" ]; then
-    echo Building aarch or ppc
-    OPENMP="-DWITH_OPENMP=1"
     QT="0"
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,7 @@
 
 set +x
 SHORT_OS_STR=$(uname -s)
+MACHINE_STR=$(uname -m)
 
 # CMake FindPNG seems to look in libpng not libpng16
 # https://gitlab.kitware.com/cmake/cmake/blob/master/Modules/FindPNG.cmake#L55
@@ -9,6 +10,8 @@ ln -s $PREFIX/include/libpng16 $PREFIX/include/libpng
 
 QT="5"
 V4L="1"
+JASPER="1"
+
 if [ "${SHORT_OS_STR:0:5}" == "Linux" ]; then
     OPENMP="-DWITH_OPENMP=1"
     # Looks like there's a bug in Opencv 3.2.0 for building with FFMPEG
@@ -32,6 +35,13 @@ if [ "${SHORT_OS_STR}" == "Darwin" ]; then
     # The default flag as of OpenCV 3.4.4 are:
     # CPU_DISPATCH:STRING=SSE4_1;SSE4_2;AVX;FP16;AVX2;AVX512_SKX
     CPU_DISPATCH_FLAGS="-DCPU_DISPATCH=SSE4_1;SSE4_2;AVX;FP16"
+fi
+
+if [ "${MACHINE_STR}" == "aarch64" ] || [ "${MACHINE_STR:0:3}" == "arm" ] || [ "${MACHINE_STR:0:3}" == "ppc" ]; then
+    echo Building aarch or ppc
+    OPENMP="-DWITH_OPENMP=1"
+    QT="0"
+    JASPER="0"
 fi
 
 CMAKE_TOOLCHAIN_CMD_FLAGS=""
@@ -118,7 +128,7 @@ cmake -LAH -G "Ninja"                                                     \
     -DBUILD_PNG=0                                                         \
     -DBUILD_OPENEXR=1                                                     \
     -DBUILD_JASPER=0                                                      \
-    -DWITH_JASPER=1                                                       \
+    -DWITH_JASPER=$JASPER                                                 \
     -DWITH_OPENJPEG=0                                                     \
     -DBUILD_JPEG=0                                                        \
     -DWITH_V4L=$V4L                                                       \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,6 +71,8 @@ requirements:
     - eigen 3.3.*
     # Jasper pin https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/659 (win) and https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/891 (aarch/ppc)
     - jasper                        # [not win and not aarch64 and not ppc64le]
+    - jasper 1.900.31               # [aarch64 or ppc64le]
+    - jasper 2.0.14                 # [win]
     - zlib
     - jpeg
     - libtiff

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ source:
     sha256: 78884f64b564a3b06dc6ee731ed33b60c6d8cd864cea07f21d94ba0f90c7b310  # [unix]
 
 build:
-  number: 0
+  number: 1
   string: py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}_{{ PKG_BUILDNUM }}
   run_exports:
     # https://abi-laboratory.pro/index.php?view=timeline&l=opencv
@@ -70,7 +70,7 @@ requirements:
     - hdf5                           # [unix]
     - eigen 3.3.*
     # Jasper pin https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/659
-    - jasper                        # [not win]
+    - jasper                        # [not win and not aarch64 and not ppc64le]
     - zlib
     - jpeg
     - libtiff
@@ -78,7 +78,7 @@ requirements:
     - harfbuzz                       # [unix]
     - libpng
     - ffmpeg                         # [not win]
-    - qt 5.12.1                      # [not osx]
+    - qt 5.12.1                      # [not osx and not aarch64 and not ppc64le]
     - liblapacke
     - freetype
     - glib                           # [unix]
@@ -87,7 +87,7 @@ requirements:
     - harfbuzz                       # [unix]
     # Don't depend on python in the run section
     # py-opencv will depend on python
-    - qt 5.12                        # [not osx]
+    - qt 5.12                        # [not osx and not aarch64 and not ppc64le]
     # https://github.com/conda-forge/opencv-feedstock/issues/174
     # Seems like the OSX ABI has changed between 2.9 and 2.10???
     # That or a dependency wasn't merged in

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,7 @@ requirements:
     - numpy
     - hdf5                           # [unix]
     - eigen 3.3.*
-    # Jasper pin https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/659
+    # Jasper pin https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/659 (win) and https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/891 (aarch/ppc)
     - jasper                        # [not win and not aarch64 and not ppc64le]
     - zlib
     - jpeg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -102,10 +102,11 @@ test:
       # Test with the two currently supported lapack implementatons
       # One test done on different versions of python on each platform
       - liblapack * *openblas         # [py==36]
-      - liblapack * *mkl              # [py==37]
+      - liblapack * *mkl              # [py==37 and not (aarch64 or ppc64le)]
+      - liblapack * *openblas         # [py==37 and (aarch64 or ppc64le)]
       - cmake
       - ninja
-      - qt 5.12.1                     # [linux]
+      - qt 5.12.1                     # [linux and not aarch64 and not ppc64le]
     files:
       - CMakeLists.txt
       - test.cpp
@@ -202,7 +203,8 @@ outputs:
         # Test with the two currently supported lapack implementatons
         # One test done on different versions of python on each platform
         - liblapack * *openblas         # [py==36]
-        - liblapack * *mkl              # [py==37]
+        - liblapack * *mkl              # [py==37 and not (aarch64 or ppc64le)]
+        - liblapack * *openblas         # [py==37 and (aarch64 or ppc64le)]
       imports:
         - cv2
         - cv2.xfeatures2d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -102,11 +102,10 @@ test:
       # Test with the two currently supported lapack implementatons
       # One test done on different versions of python on each platform
       - liblapack * *openblas         # [py==36]
-      - liblapack * *mkl              # [py==37 and not (aarch64 or ppc64le)]
-      - liblapack * *openblas         # [py==37 and (aarch64 or ppc64le)]
+      - liblapack * *mkl              # [py==37 and linux64]
       - cmake
       - ninja
-      - qt 5.12.1                     # [linux and not aarch64 and not ppc64le]
+      - qt 5.12.1                     # [linux64]
     files:
       - CMakeLists.txt
       - test.cpp
@@ -203,8 +202,7 @@ outputs:
         # Test with the two currently supported lapack implementatons
         # One test done on different versions of python on each platform
         - liblapack * *openblas         # [py==36]
-        - liblapack * *mkl              # [py==37 and not (aarch64 or ppc64le)]
-        - liblapack * *openblas         # [py==37 and (aarch64 or ppc64le)]
+        - liblapack * *mkl              # [py==37 and linux64]
       imports:
         - cv2
         - cv2.xfeatures2d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,10 +69,7 @@ requirements:
     - numpy
     - hdf5                           # [unix]
     - eigen 3.3.*
-    # Jasper pin https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/659 (win) and https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/891 (aarch/ppc)
-    - jasper                        # [not win and not aarch64 and not ppc64le]
-    - jasper 1.900.31               # [aarch64 or ppc64le]
-    - jasper 2.0.14                 # [win]
+    - jasper
     - zlib
     - jpeg
     - libtiff


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This is a preliminary test to see how much effort it will be to build opencv for aarch / ppc64le.

Opencv depends on QT, however it seems like it will take a little while to get the QT build on aarch / ppc64le to work (see https://github.com/conda-forge/qt-feedstock/pull/166). Therefore the QT part is disabled for now on those platforms.