### PR TITLE
Check that py-opencv build tests pass for python3.6

### DIFF
--- a/.ci_support/linux_64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.6.____cpython.yaml
@@ -28,6 +28,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/linux_64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.7.____cpython.yaml
@@ -28,6 +28,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/linux_64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.8.____cpython.yaml
@@ -28,6 +28,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/linux_64_numpy1.18python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.6.____73_pypy.yaml
@@ -28,6 +28,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
@@ -28,6 +28,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/linux_aarch64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.16python3.6.____cpython.yaml
@@ -32,6 +32,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/linux_aarch64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.16python3.7.____cpython.yaml
@@ -32,6 +32,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/linux_aarch64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.16python3.8.____cpython.yaml
@@ -32,6 +32,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/linux_aarch64_numpy1.18python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_aarch64_numpy1.18python3.6.____73_pypy.yaml
@@ -32,6 +32,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/linux_aarch64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.9.____cpython.yaml
@@ -32,6 +32,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/linux_ppc64le_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.16python3.6.____cpython.yaml
@@ -28,6 +28,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/linux_ppc64le_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.16python3.7.____cpython.yaml
@@ -28,6 +28,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/linux_ppc64le_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.16python3.8.____cpython.yaml
@@ -28,6 +28,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/linux_ppc64le_numpy1.18python3.6.____73_pypy.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.18python3.6.____73_pypy.yaml
@@ -28,6 +28,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/linux_ppc64le_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.19python3.9.____cpython.yaml
@@ -28,6 +28,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/osx_64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.6.____cpython.yaml
@@ -26,6 +26,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/osx_64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.7.____cpython.yaml
@@ -26,6 +26,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/osx_64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.8.____cpython.yaml
@@ -26,6 +26,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/osx_64_numpy1.18python3.6.____73_pypy.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.6.____73_pypy.yaml
@@ -26,6 +26,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
@@ -26,6 +26,10 @@ jasper:
 - '1'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -26,6 +26,10 @@ jasper:
 - '2'
 jpeg:
 - '9'
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
 liblapacke:
 - 3.9 *netlib
 libpng:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -26,6 +26,10 @@ jasper:
 - '2'
 jpeg:
 - '9'
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
 liblapacke:
 - 3.9 *netlib
 libpng:

--- a/.ci_support/win_64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.16python3.6.____cpython.yaml
@@ -12,6 +12,10 @@ jasper:
 - '2'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/win_64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.16python3.7.____cpython.yaml
@@ -12,6 +12,10 @@ jasper:
 - '2'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/win_64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.16python3.8.____cpython.yaml
@@ -12,6 +12,10 @@ jasper:
 - '2'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/.ci_support/win_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.19python3.9.____cpython.yaml
@@ -12,6 +12,10 @@ jasper:
 - '2'
 jpeg:
 - '9'
+libcblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
 liblapacke:
 - 3.8 *netlib
 libpng:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -223,6 +223,7 @@ outputs:
         - test.avi   # [unix]
       commands:
         - python run_py_test.py
+        - python -c "import cv2; print(cv2.__version__)"
         - if [[ $($PYTHON -c 'import cv2; print(cv2.__version__)') != $PKG_VERSION ]]; then exit 1; fi  # [unix]
         - python -c "import cv2; assert 'Unknown' not in cv2.videoio_registry.getBackendName(cv2.CAP_V4L)"  # [linux]
         - python -c "import cv2, re; assert re.search('Lapack:\s+YES', cv2.getBuildInformation())"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -223,7 +223,6 @@ outputs:
         - test.avi   # [unix]
       commands:
         - python run_py_test.py
-        - python -c "import cv2; print(cv2.__version__)"
         - if [[ $($PYTHON -c 'import cv2; print(cv2.__version__)') != $PKG_VERSION ]]; then exit 1; fi  # [unix]
         - python -c "import cv2; assert 'Unknown' not in cv2.videoio_registry.getBackendName(cv2.CAP_V4L)"  # [linux]
         - python -c "import cv2, re; assert re.search('Lapack:\s+YES', cv2.getBuildInformation())"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ source:
     sha256: 78884f64b564a3b06dc6ee731ed33b60c6d8cd864cea07f21d94ba0f90c7b310  # [unix]
 
 build:
-  number: 5
+  number: 6
   string: py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}_{{ PKG_BUILDNUM }}
   run_exports:
     # https://abi-laboratory.pro/index.php?view=timeline&l=opencv


### PR DESCRIPTION
Originally opened this PR to check whether the build tests pass for all build variants because the last few pull requests were not allowed to run all the tests.

It seems that re-rendering the feed may have fixed the broken Linux x64 python3.6 build because the build tests pass. However, the powerpc builds fail because Travis kills them prematurely.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Closes #258. 