### PR TITLE
WIP: With no openmp

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,40 +8,76 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_numpy1.18python3.7.____cpython:
-        CONFIG: linux_64_numpy1.18python3.7.____cpython
+      linux_64_numpy1.18openmp_implnoopenmppython3.7.____cpython:
+        CONFIG: linux_64_numpy1.18openmp_implnoopenmppython3.7.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
-      linux_64_numpy1.18python3.8.____cpython:
-        CONFIG: linux_64_numpy1.18python3.8.____cpython
+      linux_64_numpy1.18openmp_implnoopenmppython3.8.____cpython:
+        CONFIG: linux_64_numpy1.18openmp_implnoopenmppython3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
-      linux_64_numpy1.19python3.9.____cpython:
-        CONFIG: linux_64_numpy1.19python3.9.____cpython
+      linux_64_numpy1.18openmp_implopenmppython3.7.____cpython:
+        CONFIG: linux_64_numpy1.18openmp_implopenmppython3.7.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
-      linux_aarch64_numpy1.18python3.7.____cpython:
-        CONFIG: linux_aarch64_numpy1.18python3.7.____cpython
+      linux_64_numpy1.18openmp_implopenmppython3.8.____cpython:
+        CONFIG: linux_64_numpy1.18openmp_implopenmppython3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_numpy1.19openmp_implnoopenmppython3.9.____cpython:
+        CONFIG: linux_64_numpy1.19openmp_implnoopenmppython3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_numpy1.19openmp_implopenmppython3.9.____cpython:
+        CONFIG: linux_64_numpy1.19openmp_implopenmppython3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_aarch64_numpy1.18openmp_implnoopenmppython3.7.____cpython:
+        CONFIG: linux_aarch64_numpy1.18openmp_implnoopenmppython3.7.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
-      linux_aarch64_numpy1.18python3.8.____cpython:
-        CONFIG: linux_aarch64_numpy1.18python3.8.____cpython
+      linux_aarch64_numpy1.18openmp_implnoopenmppython3.8.____cpython:
+        CONFIG: linux_aarch64_numpy1.18openmp_implnoopenmppython3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
-      linux_aarch64_numpy1.19python3.9.____cpython:
-        CONFIG: linux_aarch64_numpy1.19python3.9.____cpython
+      linux_aarch64_numpy1.18openmp_implopenmppython3.7.____cpython:
+        CONFIG: linux_aarch64_numpy1.18openmp_implopenmppython3.7.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
-      linux_ppc64le_numpy1.18python3.7.____cpython:
-        CONFIG: linux_ppc64le_numpy1.18python3.7.____cpython
+      linux_aarch64_numpy1.18openmp_implopenmppython3.8.____cpython:
+        CONFIG: linux_aarch64_numpy1.18openmp_implopenmppython3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
+      linux_aarch64_numpy1.19openmp_implnoopenmppython3.9.____cpython:
+        CONFIG: linux_aarch64_numpy1.19openmp_implnoopenmppython3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
+      linux_aarch64_numpy1.19openmp_implopenmppython3.9.____cpython:
+        CONFIG: linux_aarch64_numpy1.19openmp_implopenmppython3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
+      linux_ppc64le_numpy1.18openmp_implnoopenmppython3.7.____cpython:
+        CONFIG: linux_ppc64le_numpy1.18openmp_implnoopenmppython3.7.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
-      linux_ppc64le_numpy1.18python3.8.____cpython:
-        CONFIG: linux_ppc64le_numpy1.18python3.8.____cpython
+      linux_ppc64le_numpy1.18openmp_implnoopenmppython3.8.____cpython:
+        CONFIG: linux_ppc64le_numpy1.18openmp_implnoopenmppython3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
-      linux_ppc64le_numpy1.19python3.9.____cpython:
-        CONFIG: linux_ppc64le_numpy1.19python3.9.____cpython
+      linux_ppc64le_numpy1.18openmp_implopenmppython3.7.____cpython:
+        CONFIG: linux_ppc64le_numpy1.18openmp_implopenmppython3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
+      linux_ppc64le_numpy1.18openmp_implopenmppython3.8.____cpython:
+        CONFIG: linux_ppc64le_numpy1.18openmp_implopenmppython3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
+      linux_ppc64le_numpy1.19openmp_implnoopenmppython3.9.____cpython:
+        CONFIG: linux_ppc64le_numpy1.19openmp_implnoopenmppython3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
+      linux_ppc64le_numpy1.19openmp_implopenmppython3.9.____cpython:
+        CONFIG: linux_ppc64le_numpy1.19openmp_implopenmppython3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
   timeoutInMinutes: 360

--- a/.ci_support/linux_64_numpy1.18openmp_implnoopenmppython3.7.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18openmp_implnoopenmppython3.7.____cpython.yaml
@@ -1,17 +1,19 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
 ffmpeg:
 - '4.3'
 freetype:
@@ -40,10 +42,8 @@ libtiff:
 - '4'
 libwebp:
 - '1'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
-- '1.19'
+- '1.18'
 openmp_impl:
 - noopenmp
 pin_run_as_build:
@@ -62,15 +62,21 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  qt:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.7.* *_cpython
+qt:
+- '5.12'
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - cdt_name
+  - docker_image
 - - python
   - numpy
 zlib:

--- a/.ci_support/linux_64_numpy1.18openmp_implnoopenmppython3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18openmp_implnoopenmppython3.8.____cpython.yaml
@@ -1,17 +1,19 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
 ffmpeg:
 - '4.3'
 freetype:
@@ -40,10 +42,8 @@ libtiff:
 - '4'
 libwebp:
 - '1'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
-- '1.19'
+- '1.18'
 openmp_impl:
 - noopenmp
 pin_run_as_build:
@@ -62,15 +62,21 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  qt:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
+qt:
+- '5.12'
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - cdt_name
+  - docker_image
 - - python
   - numpy
 zlib:

--- a/.ci_support/linux_64_numpy1.18openmp_implopenmppython3.7.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18openmp_implopenmppython3.7.____cpython.yaml
@@ -1,17 +1,19 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
 ffmpeg:
 - '4.3'
 freetype:
@@ -40,12 +42,10 @@ libtiff:
 - '4'
 libwebp:
 - '1'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
-- '1.19'
+- '1.18'
 openmp_impl:
-- noopenmp
+- openmp
 pin_run_as_build:
   freetype:
     max_pin: x
@@ -62,15 +62,21 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  qt:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.7.* *_cpython
+qt:
+- '5.12'
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - cdt_name
+  - docker_image
 - - python
   - numpy
 zlib:

--- a/.ci_support/linux_64_numpy1.18openmp_implopenmppython3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18openmp_implopenmppython3.8.____cpython.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '9'
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-comp7
 ffmpeg:
 - '4.3'
 freetype:
@@ -43,7 +43,9 @@ libtiff:
 libwebp:
 - '1'
 numpy:
-- '1.19'
+- '1.18'
+openmp_impl:
+- openmp
 pin_run_as_build:
   freetype:
     max_pin: x
@@ -60,15 +62,21 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  qt:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
+qt:
+- '5.12'
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - cdt_name
+  - docker_image
 - - python
   - numpy
 zlib:

--- a/.ci_support/linux_64_numpy1.19openmp_implnoopenmppython3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.19openmp_implnoopenmppython3.9.____cpython.yaml
@@ -43,7 +43,9 @@ libtiff:
 libwebp:
 - '1'
 numpy:
-- '1.18'
+- '1.19'
+openmp_impl:
+- noopenmp
 pin_run_as_build:
   freetype:
     max_pin: x
@@ -65,7 +67,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 qt:
 - '5.12'
 target_platform:

--- a/.ci_support/linux_64_numpy1.19openmp_implopenmppython3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.19openmp_implopenmppython3.9.____cpython.yaml
@@ -1,17 +1,19 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
 ffmpeg:
 - '4.3'
 freetype:
@@ -40,12 +42,10 @@ libtiff:
 - '4'
 libwebp:
 - '1'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
 - '1.19'
 openmp_impl:
-- noopenmp
+- openmp
 pin_run_as_build:
   freetype:
     max_pin: x
@@ -62,15 +62,21 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  qt:
+    max_pin: x.x
   zlib:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+qt:
+- '5.12'
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - cdt_name
+  - docker_image
 - - python
   - numpy
 zlib:

--- a/.ci_support/linux_aarch64_numpy1.18openmp_implnoopenmppython3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.18openmp_implnoopenmppython3.7.____cpython.yaml
@@ -48,6 +48,8 @@ libwebp:
 - '1'
 numpy:
 - '1.18'
+openmp_impl:
+- noopenmp
 pin_run_as_build:
   freetype:
     max_pin: x
@@ -67,7 +69,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.7.* *_cpython
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_numpy1.18openmp_implnoopenmppython3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.18openmp_implnoopenmppython3.8.____cpython.yaml
@@ -1,7 +1,11 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '9'
+cdt_arch:
+- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -13,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-aarch64
 ffmpeg:
 - '4.3'
 freetype:
@@ -44,6 +48,8 @@ libwebp:
 - '1'
 numpy:
 - '1.18'
+openmp_impl:
+- noopenmp
 pin_run_as_build:
   freetype:
     max_pin: x
@@ -63,9 +69,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.8.* *_cpython
 target_platform:
-- linux-ppc64le
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_numpy1.18openmp_implopenmppython3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.18openmp_implopenmppython3.7.____cpython.yaml
@@ -1,17 +1,23 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
 ffmpeg:
 - '4.3'
 freetype:
@@ -40,12 +46,10 @@ libtiff:
 - '4'
 libwebp:
 - '1'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
-- '1.19'
+- '1.18'
 openmp_impl:
-- noopenmp
+- openmp
 pin_run_as_build:
   freetype:
     max_pin: x
@@ -65,9 +69,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.7.* *_cpython
 target_platform:
-- osx-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_numpy1.18openmp_implopenmppython3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.18openmp_implopenmppython3.8.____cpython.yaml
@@ -1,17 +1,23 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
 ffmpeg:
 - '4.3'
 freetype:
@@ -40,12 +46,10 @@ libtiff:
 - '4'
 libwebp:
 - '1'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
-- '1.19'
+- '1.18'
 openmp_impl:
-- noopenmp
+- openmp
 pin_run_as_build:
   freetype:
     max_pin: x
@@ -65,9 +69,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 target_platform:
-- osx-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_numpy1.19openmp_implnoopenmppython3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19openmp_implnoopenmppython3.9.____cpython.yaml
@@ -1,17 +1,23 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
 ffmpeg:
 - '4.3'
 freetype:
@@ -40,8 +46,6 @@ libtiff:
 - '4'
 libwebp:
 - '1'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
 - '1.19'
 openmp_impl:
@@ -67,7 +71,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 target_platform:
-- osx-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_numpy1.19openmp_implopenmppython3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19openmp_implopenmppython3.9.____cpython.yaml
@@ -47,7 +47,9 @@ libtiff:
 libwebp:
 - '1'
 numpy:
-- '1.18'
+- '1.19'
+openmp_impl:
+- openmp
 pin_run_as_build:
   freetype:
     max_pin: x
@@ -67,7 +69,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.9.* *_cpython
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_numpy1.18openmp_implnoopenmppython3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.18openmp_implnoopenmppython3.7.____cpython.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '9'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-ppc64le
 ffmpeg:
 - '4.3'
 freetype:
@@ -44,6 +44,8 @@ libwebp:
 - '1'
 numpy:
 - '1.18'
+openmp_impl:
+- noopenmp
 pin_run_as_build:
   freetype:
     max_pin: x
@@ -60,21 +62,15 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
-  qt:
-    max_pin: x.x
   zlib:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
-qt:
-- '5.12'
 target_platform:
-- linux-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cdt_name
-  - docker_image
 - - python
   - numpy
 zlib:

--- a/.ci_support/linux_ppc64le_numpy1.18openmp_implnoopenmppython3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.18openmp_implnoopenmppython3.8.____cpython.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '9'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-ppc64le
 ffmpeg:
 - '4.3'
 freetype:
@@ -43,7 +43,9 @@ libtiff:
 libwebp:
 - '1'
 numpy:
-- '1.19'
+- '1.18'
+openmp_impl:
+- noopenmp
 pin_run_as_build:
   freetype:
     max_pin: x
@@ -60,21 +62,15 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
-  qt:
-    max_pin: x.x
   zlib:
     max_pin: x.x
 python:
-- 3.9.* *_cpython
-qt:
-- '5.12'
+- 3.8.* *_cpython
 target_platform:
-- linux-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cdt_name
-  - docker_image
 - - python
   - numpy
 zlib:

--- a/.ci_support/linux_ppc64le_numpy1.18openmp_implopenmppython3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.18openmp_implopenmppython3.7.____cpython.yaml
@@ -1,17 +1,19 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
 ffmpeg:
 - '4.3'
 freetype:
@@ -40,12 +42,10 @@ libtiff:
 - '4'
 libwebp:
 - '1'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
-- '1.19'
+- '1.18'
 openmp_impl:
-- noopenmp
+- openmp
 pin_run_as_build:
   freetype:
     max_pin: x
@@ -65,9 +65,9 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.7.* *_cpython
 target_platform:
-- osx-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_numpy1.18openmp_implopenmppython3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.18openmp_implopenmppython3.8.____cpython.yaml
@@ -44,6 +44,8 @@ libwebp:
 - '1'
 numpy:
 - '1.18'
+openmp_impl:
+- openmp
 pin_run_as_build:
   freetype:
     max_pin: x

--- a/.ci_support/linux_ppc64le_numpy1.19openmp_implnoopenmppython3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.19openmp_implnoopenmppython3.9.____cpython.yaml
@@ -1,11 +1,7 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '9'
-cdt_arch:
-- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -17,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-ppc64le
 ffmpeg:
 - '4.3'
 freetype:
@@ -48,6 +44,8 @@ libwebp:
 - '1'
 numpy:
 - '1.19'
+openmp_impl:
+- noopenmp
 pin_run_as_build:
   freetype:
     max_pin: x
@@ -69,7 +67,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 target_platform:
-- linux-aarch64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_numpy1.19openmp_implopenmppython3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.19openmp_implopenmppython3.9.____cpython.yaml
@@ -1,17 +1,19 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
 ffmpeg:
 - '4.3'
 freetype:
@@ -40,12 +42,10 @@ libtiff:
 - '4'
 libwebp:
 - '1'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
 - '1.19'
 openmp_impl:
-- noopenmp
+- openmp
 pin_run_as_build:
   freetype:
     max_pin: x
@@ -67,7 +67,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 target_platform:
-- osx-64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.7.____cpython.yaml
@@ -44,6 +44,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
 - '1.18'
+openmp_impl:
+- noopenmp
 pin_run_as_build:
   freetype:
     max_pin: x

--- a/.ci_support/osx_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.8.____cpython.yaml
@@ -44,6 +44,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
 - '1.18'
+openmp_impl:
+- noopenmp
 pin_run_as_build:
   freetype:
     max_pin: x

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -44,6 +44,8 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:
 - '1.19'
+openmp_impl:
+- noopenmp
 pin_run_as_build:
   freetype:
     max_pin: x

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -44,6 +44,8 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:
 - '1.19'
+openmp_impl:
+- noopenmp
 pin_run_as_build:
   freetype:
     max_pin: x

--- a/.ci_support/win_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.18python3.7.____cpython.yaml
@@ -28,6 +28,8 @@ libwebp:
 - '1'
 numpy:
 - '1.18'
+openmp_impl:
+- noopenmp
 pin_run_as_build:
   freetype:
     max_pin: x

--- a/.ci_support/win_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.18python3.8.____cpython.yaml
@@ -28,6 +28,8 @@ libwebp:
 - '1'
 numpy:
 - '1.18'
+openmp_impl:
+- noopenmp
 pin_run_as_build:
   freetype:
     max_pin: x

--- a/.ci_support/win_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.19python3.9.____cpython.yaml
@@ -28,6 +28,8 @@ libwebp:
 - '1'
 numpy:
 - '1.19'
+openmp_impl:
+- noopenmp
 pin_run_as_build:
   freetype:
     max_pin: x

--- a/README.md
+++ b/README.md
@@ -27,66 +27,129 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_numpy1.18python3.7.____cpython</td>
+              <td>linux_64_numpy1.18openmp_implnoopenmppython3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.18python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.18openmp_implnoopenmppython3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.18python3.8.____cpython</td>
+              <td>linux_64_numpy1.18openmp_implnoopenmppython3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.18python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.18openmp_implnoopenmppython3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.19python3.9.____cpython</td>
+              <td>linux_64_numpy1.18openmp_implopenmppython3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.19python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.18openmp_implopenmppython3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.18python3.7.____cpython</td>
+              <td>linux_64_numpy1.18openmp_implopenmppython3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.18python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.18openmp_implopenmppython3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.18python3.8.____cpython</td>
+              <td>linux_64_numpy1.19openmp_implnoopenmppython3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.18python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.19openmp_implnoopenmppython3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.19python3.9.____cpython</td>
+              <td>linux_64_numpy1.19openmp_implopenmppython3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.19python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_64_numpy1.19openmp_implopenmppython3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_numpy1.18python3.7.____cpython</td>
+              <td>linux_aarch64_numpy1.18openmp_implnoopenmppython3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.18python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.18openmp_implnoopenmppython3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_numpy1.18python3.8.____cpython</td>
+              <td>linux_aarch64_numpy1.18openmp_implnoopenmppython3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.18python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.18openmp_implnoopenmppython3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_numpy1.19python3.9.____cpython</td>
+              <td>linux_aarch64_numpy1.18openmp_implopenmppython3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.19python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.18openmp_implopenmppython3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.18openmp_implopenmppython3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.18openmp_implopenmppython3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.19openmp_implnoopenmppython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.19openmp_implnoopenmppython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.19openmp_implopenmppython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.19openmp_implopenmppython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_numpy1.18openmp_implnoopenmppython3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.18openmp_implnoopenmppython3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_numpy1.18openmp_implnoopenmppython3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.18openmp_implnoopenmppython3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_numpy1.18openmp_implopenmppython3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.18openmp_implopenmppython3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_numpy1.18openmp_implopenmppython3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.18openmp_implopenmppython3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_numpy1.19openmp_implnoopenmppython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.19openmp_implnoopenmppython3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_numpy1.19openmp_implopenmppython3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4567&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/opencv-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_numpy1.19openmp_implopenmppython3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,7 +16,12 @@ if [[ "${target_platform}" == linux-* ]]; then
 
     export CPPFLAGS="${CPPFLAGS//-std=c++17/-std=c++11}"
     export CXXFLAGS="${CXXFLAGS//-std=c++17/-std=c++11}"
-    OPENMP="-DWITH_OPENMP=1"
+    if [[ "${openmp_impl}" == "openmp" ]]; then
+        OPENMP="-DWITH_OPENMP=1"
+    else
+        OPENMP="-DWITH_OPENMP=0"
+    fi
+
 fi
 if [[ "${target_platform}" == osx-* ]]; then
     QT="0"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+openmp_impl:
+  - noopenmp
+  - openmp      # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,8 +43,8 @@ source:
     sha256: 78884f64b564a3b06dc6ee731ed33b60c6d8cd864cea07f21d94ba0f90c7b310  # [unix]
 
 build:
-  number: 5
-  string: py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
+  number: 6
+  string: py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ openmp_impl }}
   run_exports:
     # https://abi-laboratory.pro/index.php?view=timeline&l=opencv
     # Things seem to change every patch versions, mostly the dnn module
@@ -63,7 +63,7 @@ requirements:
     - m2-patch                       # [win]
     - cmake
     - ninja
-    - libgomp                        # [linux]
+    - libgomp                        # [linux and (openmp_impl == "openmp")]
     # ICE when enabling this
     # - llvm-openmp                    # [osx]
     - {{ compiler('c') }}
@@ -200,7 +200,7 @@ outputs:
   - name: libopencv
   - name: opencv
     build:
-      string: py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
+      string: py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ openmp_impl }}
     requirements:
       host:
         # Explicitely add a python requirement so that the hash changes between
@@ -213,7 +213,7 @@ outputs:
 
   - name: py-opencv
     build:
-      string: py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
+      string: py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ openmp_impl }}
       run_exports:
         # Should we even have this???
         # don't pin the python version so hard.


### PR DESCRIPTION
It seems that tensorflow prefers opencv without openmp. I'm trying to see if we can build a variant without it, and have it organized in a fashion that will allow us to preferrebly pick by default, the preferred variant.


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
