### PR TITLE
Use OpenVINO with python API

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ source:
     sha256: 78884f64b564a3b06dc6ee731ed33b60c6d8cd864cea07f21d94ba0f90c7b310
 
 build:
-  number: 0
+  number: 1
   string: py{{ PY_VER_MAJOR }}{{ PY_VER_MINOR }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
   run_exports:
     # https://abi-laboratory.pro/index.php?view=timeline&l=opencv
@@ -106,7 +106,7 @@ requirements:
     - libwebp
     - qt-main                        # [not osx and not ppc64le]
     - zlib
-    - libopenvino-dev                # [not ppc64le]
+    - openvino                       # [not ppc64le]
 
 test:
     requires:


### PR DESCRIPTION
**Reason:**
It turned out that in case of:
- `libopenvino-dev` installed from conda-forge (C++ API and libs only)
- `openvino` installed from pypi (Python API and libs internally)

We have an issue that PyPi package starts to look for C++ libraries to conda-forge package and we have unresolved symbols, because these packages are compiled with different compilers (ABIs). 
PyPI package looks for C++ libraries to conda-forge package, because conda-forge overrides LD_LIBRARY_PATH and PyPI package ignores its RUNPATH (has lower priority than LD_LIBRARY_PATH). One of the solutions is to use RPATH on OpenVINO PyPI package, but it can be done only in next release.

**Origin of the issue:** 
https://github.com/openvinotoolkit/openvino/issues/20217

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
