### PR TITLE
Switch JPEG2000 backend from JasPer to OpenJPEG

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -12,162 +12,202 @@ jobs:
         CONFIG: osx_64_hdf51.14.6python3.10.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf51.14.6python3.10.____cpythonqt_versionnone:
         CONFIG: osx_64_hdf51.14.6python3.10.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf51.14.6python3.11.____cpythonqt_version6:
         CONFIG: osx_64_hdf51.14.6python3.11.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf51.14.6python3.11.____cpythonqt_versionnone:
         CONFIG: osx_64_hdf51.14.6python3.11.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf51.14.6python3.12.____cpythonqt_version6:
         CONFIG: osx_64_hdf51.14.6python3.12.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf51.14.6python3.12.____cpythonqt_versionnone:
         CONFIG: osx_64_hdf51.14.6python3.12.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf51.14.6python3.13.____cp313qt_version6:
         CONFIG: osx_64_hdf51.14.6python3.13.____cp313qt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf51.14.6python3.13.____cp313qt_versionnone:
         CONFIG: osx_64_hdf51.14.6python3.13.____cp313qt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf51.14.6python3.14.____cp314qt_version6:
         CONFIG: osx_64_hdf51.14.6python3.14.____cp314qt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf51.14.6python3.14.____cp314qt_versionnone:
         CONFIG: osx_64_hdf51.14.6python3.14.____cp314qt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf52python3.10.____cpythonqt_version6:
         CONFIG: osx_64_hdf52python3.10.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf52python3.10.____cpythonqt_versionnone:
         CONFIG: osx_64_hdf52python3.10.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf52python3.11.____cpythonqt_version6:
         CONFIG: osx_64_hdf52python3.11.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf52python3.11.____cpythonqt_versionnone:
         CONFIG: osx_64_hdf52python3.11.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf52python3.12.____cpythonqt_version6:
         CONFIG: osx_64_hdf52python3.12.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf52python3.12.____cpythonqt_versionnone:
         CONFIG: osx_64_hdf52python3.12.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf52python3.13.____cp313qt_version6:
         CONFIG: osx_64_hdf52python3.13.____cp313qt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf52python3.13.____cp313qt_versionnone:
         CONFIG: osx_64_hdf52python3.13.____cp313qt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf52python3.14.____cp314qt_version6:
         CONFIG: osx_64_hdf52python3.14.____cp314qt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_hdf52python3.14.____cp314qt_versionnone:
         CONFIG: osx_64_hdf52python3.14.____cp314qt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf51.14.6python3.10.____cpythonqt_version6:
         CONFIG: osx_arm64_hdf51.14.6python3.10.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf51.14.6python3.10.____cpythonqt_versionnone:
         CONFIG: osx_arm64_hdf51.14.6python3.10.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf51.14.6python3.11.____cpythonqt_version6:
         CONFIG: osx_arm64_hdf51.14.6python3.11.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf51.14.6python3.11.____cpythonqt_versionnone:
         CONFIG: osx_arm64_hdf51.14.6python3.11.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf51.14.6python3.12.____cpythonqt_version6:
         CONFIG: osx_arm64_hdf51.14.6python3.12.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf51.14.6python3.12.____cpythonqt_versionnone:
         CONFIG: osx_arm64_hdf51.14.6python3.12.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf51.14.6python3.13.____cp313qt_version6:
         CONFIG: osx_arm64_hdf51.14.6python3.13.____cp313qt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf51.14.6python3.13.____cp313qt_versionnone:
         CONFIG: osx_arm64_hdf51.14.6python3.13.____cp313qt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf51.14.6python3.14.____cp314qt_version6:
         CONFIG: osx_arm64_hdf51.14.6python3.14.____cp314qt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf51.14.6python3.14.____cp314qt_versionnone:
         CONFIG: osx_arm64_hdf51.14.6python3.14.____cp314qt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf52python3.10.____cpythonqt_version6:
         CONFIG: osx_arm64_hdf52python3.10.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf52python3.10.____cpythonqt_versionnone:
         CONFIG: osx_arm64_hdf52python3.10.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf52python3.11.____cpythonqt_version6:
         CONFIG: osx_arm64_hdf52python3.11.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf52python3.11.____cpythonqt_versionnone:
         CONFIG: osx_arm64_hdf52python3.11.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf52python3.12.____cpythonqt_version6:
         CONFIG: osx_arm64_hdf52python3.12.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf52python3.12.____cpythonqt_versionnone:
         CONFIG: osx_arm64_hdf52python3.12.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf52python3.13.____cp313qt_version6:
         CONFIG: osx_arm64_hdf52python3.13.____cp313qt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf52python3.13.____cp313qt_versionnone:
         CONFIG: osx_arm64_hdf52python3.13.____cp313qt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf52python3.14.____cp314qt_version6:
         CONFIG: osx_arm64_hdf52python3.14.____cp314qt_version6
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_hdf52python3.14.____cp314qt_versionnone:
         CONFIG: osx_arm64_hdf52python3.14.____cp314qt_versionnone
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
     maxParallel: 33
   timeoutInMinutes: 360
   variables: {}

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,63 +11,83 @@ jobs:
       win_64_hdf51.14.6python3.10.____cpythonqt_version6:
         CONFIG: win_64_hdf51.14.6python3.10.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf51.14.6python3.10.____cpythonqt_versionnone:
         CONFIG: win_64_hdf51.14.6python3.10.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf51.14.6python3.11.____cpythonqt_version6:
         CONFIG: win_64_hdf51.14.6python3.11.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf51.14.6python3.11.____cpythonqt_versionnone:
         CONFIG: win_64_hdf51.14.6python3.11.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf51.14.6python3.12.____cpythonqt_version6:
         CONFIG: win_64_hdf51.14.6python3.12.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf51.14.6python3.12.____cpythonqt_versionnone:
         CONFIG: win_64_hdf51.14.6python3.12.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf51.14.6python3.13.____cp313qt_version6:
         CONFIG: win_64_hdf51.14.6python3.13.____cp313qt_version6
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf51.14.6python3.13.____cp313qt_versionnone:
         CONFIG: win_64_hdf51.14.6python3.13.____cp313qt_versionnone
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf51.14.6python3.14.____cp314qt_version6:
         CONFIG: win_64_hdf51.14.6python3.14.____cp314qt_version6
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf51.14.6python3.14.____cp314qt_versionnone:
         CONFIG: win_64_hdf51.14.6python3.14.____cp314qt_versionnone
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf52python3.10.____cpythonqt_version6:
         CONFIG: win_64_hdf52python3.10.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf52python3.10.____cpythonqt_versionnone:
         CONFIG: win_64_hdf52python3.10.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf52python3.11.____cpythonqt_version6:
         CONFIG: win_64_hdf52python3.11.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf52python3.11.____cpythonqt_versionnone:
         CONFIG: win_64_hdf52python3.11.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf52python3.12.____cpythonqt_version6:
         CONFIG: win_64_hdf52python3.12.____cpythonqt_version6
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf52python3.12.____cpythonqt_versionnone:
         CONFIG: win_64_hdf52python3.12.____cpythonqt_versionnone
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf52python3.13.____cp313qt_version6:
         CONFIG: win_64_hdf52python3.13.____cp313qt_version6
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf52python3.13.____cp313qt_versionnone:
         CONFIG: win_64_hdf52python3.13.____cp313qt_versionnone
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf52python3.14.____cp314qt_version6:
         CONFIG: win_64_hdf52python3.14.____cp314qt_version6
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_hdf52python3.14.____cp314qt_versionnone:
         CONFIG: win_64_hdf52python3.14.____cp314qt_versionnone
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
     maxParallel: 17
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.10.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.10.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.10.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.10.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.11.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.11.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.11.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.11.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.12.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.12.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.12.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.12.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.13.____cp313qt_version6.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.13.____cp313qt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.13.____cp313qt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.13.____cp313qt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.14.____cp314qt_version6.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.14.____cp314qt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.14.____cp314qt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.14.____cp314qt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.10.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.10.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.10.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.10.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.11.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.11.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.11.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.11.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.12.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.12.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.12.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.12.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.13.____cp313qt_version6.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.13.____cp313qt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.13.____cp313qt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.13.____cp313qt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.14.____cp314qt_version6.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.14.____cp314qt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.14.____cp314qt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.14.____cp314qt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.10.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.10.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.10.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.10.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.11.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.11.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.11.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.11.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.12.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.12.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.12.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.12.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.13.____cp313qt_version6.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.13.____cp313qt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.13.____cp313qt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.13.____cp313qt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.14.____cp314qt_version6.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.14.____cp314qt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.14.____cp314qt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.14.____cp314qt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.10.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.10.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.10.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.10.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.11.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.11.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.11.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.11.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.12.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.12.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.12.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.12.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.13.____cp313qt_version6.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.13.____cp313qt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.13.____cp313qt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.13.____cp313qt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.14.____cp314qt_version6.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.14.____cp314qt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.14.____cp314qt_versionnone.yaml
+++ b/.ci_support/linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.14.____cp314qt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf51.14.6python3.10.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_aarch64_hdf51.14.6python3.10.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf51.14.6python3.10.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_aarch64_hdf51.14.6python3.10.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf51.14.6python3.11.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_aarch64_hdf51.14.6python3.11.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf51.14.6python3.11.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_aarch64_hdf51.14.6python3.11.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf51.14.6python3.12.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_aarch64_hdf51.14.6python3.12.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf51.14.6python3.12.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_aarch64_hdf51.14.6python3.12.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf51.14.6python3.13.____cp313qt_version6.yaml
+++ b/.ci_support/linux_aarch64_hdf51.14.6python3.13.____cp313qt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf51.14.6python3.13.____cp313qt_versionnone.yaml
+++ b/.ci_support/linux_aarch64_hdf51.14.6python3.13.____cp313qt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf51.14.6python3.14.____cp314qt_version6.yaml
+++ b/.ci_support/linux_aarch64_hdf51.14.6python3.14.____cp314qt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf51.14.6python3.14.____cp314qt_versionnone.yaml
+++ b/.ci_support/linux_aarch64_hdf51.14.6python3.14.____cp314qt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf52python3.10.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_aarch64_hdf52python3.10.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf52python3.10.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_aarch64_hdf52python3.10.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf52python3.11.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_aarch64_hdf52python3.11.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf52python3.11.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_aarch64_hdf52python3.11.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf52python3.12.____cpythonqt_version6.yaml
+++ b/.ci_support/linux_aarch64_hdf52python3.12.____cpythonqt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf52python3.12.____cpythonqt_versionnone.yaml
+++ b/.ci_support/linux_aarch64_hdf52python3.12.____cpythonqt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf52python3.13.____cp313qt_version6.yaml
+++ b/.ci_support/linux_aarch64_hdf52python3.13.____cp313qt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf52python3.13.____cp313qt_versionnone.yaml
+++ b/.ci_support/linux_aarch64_hdf52python3.13.____cp313qt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf52python3.14.____cp314qt_version6.yaml
+++ b/.ci_support/linux_aarch64_hdf52python3.14.____cp314qt_version6.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_hdf52python3.14.____cp314qt_versionnone.yaml
+++ b/.ci_support/linux_aarch64_hdf52python3.14.____cp314qt_versionnone.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -58,6 +56,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_hdf51.14.6python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_hdf51.14.6python3.10.____cpython.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -56,6 +54,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_hdf51.14.6python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_hdf51.14.6python3.11.____cpython.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -56,6 +54,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_hdf51.14.6python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_hdf51.14.6python3.12.____cpython.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -56,6 +54,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_hdf51.14.6python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_hdf51.14.6python3.13.____cp313.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -56,6 +54,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_hdf51.14.6python3.14.____cp314.yaml
+++ b/.ci_support/linux_ppc64le_hdf51.14.6python3.14.____cp314.yaml
@@ -28,8 +28,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -56,6 +54,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_hdf52python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_hdf52python3.10.____cpython.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -56,6 +54,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_hdf52python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_hdf52python3.11.____cpython.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -56,6 +54,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_hdf52python3.12.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_hdf52python3.12.____cpython.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -56,6 +54,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_hdf52python3.13.____cp313.yaml
+++ b/.ci_support/linux_ppc64le_hdf52python3.13.____cp313.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -56,6 +54,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_ppc64le_hdf52python3.14.____cp314.yaml
+++ b/.ci_support/linux_ppc64le_hdf52python3.14.____cp314.yaml
@@ -28,8 +28,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -56,6 +54,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf51.14.6python3.10.____cpythonqt_version6.yaml
+++ b/.ci_support/osx_64_hdf51.14.6python3.10.____cpythonqt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf51.14.6python3.10.____cpythonqt_versionnone.yaml
+++ b/.ci_support/osx_64_hdf51.14.6python3.10.____cpythonqt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf51.14.6python3.11.____cpythonqt_version6.yaml
+++ b/.ci_support/osx_64_hdf51.14.6python3.11.____cpythonqt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf51.14.6python3.11.____cpythonqt_versionnone.yaml
+++ b/.ci_support/osx_64_hdf51.14.6python3.11.____cpythonqt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf51.14.6python3.12.____cpythonqt_version6.yaml
+++ b/.ci_support/osx_64_hdf51.14.6python3.12.____cpythonqt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf51.14.6python3.12.____cpythonqt_versionnone.yaml
+++ b/.ci_support/osx_64_hdf51.14.6python3.12.____cpythonqt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf51.14.6python3.13.____cp313qt_version6.yaml
+++ b/.ci_support/osx_64_hdf51.14.6python3.13.____cp313qt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf51.14.6python3.13.____cp313qt_versionnone.yaml
+++ b/.ci_support/osx_64_hdf51.14.6python3.13.____cp313qt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf51.14.6python3.14.____cp314qt_version6.yaml
+++ b/.ci_support/osx_64_hdf51.14.6python3.14.____cp314qt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf51.14.6python3.14.____cp314qt_versionnone.yaml
+++ b/.ci_support/osx_64_hdf51.14.6python3.14.____cp314qt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf52python3.10.____cpythonqt_version6.yaml
+++ b/.ci_support/osx_64_hdf52python3.10.____cpythonqt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf52python3.10.____cpythonqt_versionnone.yaml
+++ b/.ci_support/osx_64_hdf52python3.10.____cpythonqt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf52python3.11.____cpythonqt_version6.yaml
+++ b/.ci_support/osx_64_hdf52python3.11.____cpythonqt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf52python3.11.____cpythonqt_versionnone.yaml
+++ b/.ci_support/osx_64_hdf52python3.11.____cpythonqt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf52python3.12.____cpythonqt_version6.yaml
+++ b/.ci_support/osx_64_hdf52python3.12.____cpythonqt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf52python3.12.____cpythonqt_versionnone.yaml
+++ b/.ci_support/osx_64_hdf52python3.12.____cpythonqt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf52python3.13.____cp313qt_version6.yaml
+++ b/.ci_support/osx_64_hdf52python3.13.____cp313qt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf52python3.13.____cp313qt_versionnone.yaml
+++ b/.ci_support/osx_64_hdf52python3.13.____cp313qt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf52python3.14.____cp314qt_version6.yaml
+++ b/.ci_support/osx_64_hdf52python3.14.____cp314qt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_hdf52python3.14.____cp314qt_versionnone.yaml
+++ b/.ci_support/osx_64_hdf52python3.14.____cp314qt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf51.14.6python3.10.____cpythonqt_version6.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6python3.10.____cpythonqt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf51.14.6python3.10.____cpythonqt_versionnone.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6python3.10.____cpythonqt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf51.14.6python3.11.____cpythonqt_version6.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6python3.11.____cpythonqt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf51.14.6python3.11.____cpythonqt_versionnone.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6python3.11.____cpythonqt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf51.14.6python3.12.____cpythonqt_version6.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6python3.12.____cpythonqt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf51.14.6python3.12.____cpythonqt_versionnone.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6python3.12.____cpythonqt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf51.14.6python3.13.____cp313qt_version6.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6python3.13.____cp313qt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf51.14.6python3.13.____cp313qt_versionnone.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6python3.13.____cp313qt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf51.14.6python3.14.____cp314qt_version6.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6python3.14.____cp314qt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf51.14.6python3.14.____cp314qt_versionnone.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.6python3.14.____cp314qt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf52python3.10.____cpythonqt_version6.yaml
+++ b/.ci_support/osx_arm64_hdf52python3.10.____cpythonqt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf52python3.10.____cpythonqt_versionnone.yaml
+++ b/.ci_support/osx_arm64_hdf52python3.10.____cpythonqt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf52python3.11.____cpythonqt_version6.yaml
+++ b/.ci_support/osx_arm64_hdf52python3.11.____cpythonqt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf52python3.11.____cpythonqt_versionnone.yaml
+++ b/.ci_support/osx_arm64_hdf52python3.11.____cpythonqt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf52python3.12.____cpythonqt_version6.yaml
+++ b/.ci_support/osx_arm64_hdf52python3.12.____cpythonqt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf52python3.12.____cpythonqt_versionnone.yaml
+++ b/.ci_support/osx_arm64_hdf52python3.12.____cpythonqt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf52python3.13.____cp313qt_version6.yaml
+++ b/.ci_support/osx_arm64_hdf52python3.13.____cp313qt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf52python3.13.____cp313qt_versionnone.yaml
+++ b/.ci_support/osx_arm64_hdf52python3.13.____cp313qt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf52python3.14.____cp314qt_version6.yaml
+++ b/.ci_support/osx_arm64_hdf52python3.14.____cp314qt_version6.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_hdf52python3.14.____cp314qt_versionnone.yaml
+++ b/.ci_support/osx_arm64_hdf52python3.14.____cp314qt_versionnone.yaml
@@ -30,8 +30,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -62,6 +60,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf51.14.6python3.10.____cpythonqt_version6.yaml
+++ b/.ci_support/win_64_hdf51.14.6python3.10.____cpythonqt_version6.yaml
@@ -20,8 +20,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf51.14.6python3.10.____cpythonqt_versionnone.yaml
+++ b/.ci_support/win_64_hdf51.14.6python3.10.____cpythonqt_versionnone.yaml
@@ -20,8 +20,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf51.14.6python3.11.____cpythonqt_version6.yaml
+++ b/.ci_support/win_64_hdf51.14.6python3.11.____cpythonqt_version6.yaml
@@ -20,8 +20,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf51.14.6python3.11.____cpythonqt_versionnone.yaml
+++ b/.ci_support/win_64_hdf51.14.6python3.11.____cpythonqt_versionnone.yaml
@@ -20,8 +20,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf51.14.6python3.12.____cpythonqt_version6.yaml
+++ b/.ci_support/win_64_hdf51.14.6python3.12.____cpythonqt_version6.yaml
@@ -20,8 +20,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf51.14.6python3.12.____cpythonqt_versionnone.yaml
+++ b/.ci_support/win_64_hdf51.14.6python3.12.____cpythonqt_versionnone.yaml
@@ -20,8 +20,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf51.14.6python3.13.____cp313qt_version6.yaml
+++ b/.ci_support/win_64_hdf51.14.6python3.13.____cp313qt_version6.yaml
@@ -20,8 +20,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf51.14.6python3.13.____cp313qt_versionnone.yaml
+++ b/.ci_support/win_64_hdf51.14.6python3.13.____cp313qt_versionnone.yaml
@@ -20,8 +20,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf51.14.6python3.14.____cp314qt_version6.yaml
+++ b/.ci_support/win_64_hdf51.14.6python3.14.____cp314qt_version6.yaml
@@ -20,8 +20,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf51.14.6python3.14.____cp314qt_versionnone.yaml
+++ b/.ci_support/win_64_hdf51.14.6python3.14.____cp314qt_versionnone.yaml
@@ -20,8 +20,6 @@ hdf5:
 - 1.14.6
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf52python3.10.____cpythonqt_version6.yaml
+++ b/.ci_support/win_64_hdf52python3.10.____cpythonqt_version6.yaml
@@ -20,8 +20,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf52python3.10.____cpythonqt_versionnone.yaml
+++ b/.ci_support/win_64_hdf52python3.10.____cpythonqt_versionnone.yaml
@@ -20,8 +20,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf52python3.11.____cpythonqt_version6.yaml
+++ b/.ci_support/win_64_hdf52python3.11.____cpythonqt_version6.yaml
@@ -20,8 +20,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf52python3.11.____cpythonqt_versionnone.yaml
+++ b/.ci_support/win_64_hdf52python3.11.____cpythonqt_versionnone.yaml
@@ -20,8 +20,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf52python3.12.____cpythonqt_version6.yaml
+++ b/.ci_support/win_64_hdf52python3.12.____cpythonqt_version6.yaml
@@ -20,8 +20,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf52python3.12.____cpythonqt_versionnone.yaml
+++ b/.ci_support/win_64_hdf52python3.12.____cpythonqt_versionnone.yaml
@@ -20,8 +20,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf52python3.13.____cp313qt_version6.yaml
+++ b/.ci_support/win_64_hdf52python3.13.____cp313qt_version6.yaml
@@ -20,8 +20,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf52python3.13.____cp313qt_versionnone.yaml
+++ b/.ci_support/win_64_hdf52python3.13.____cp313qt_versionnone.yaml
@@ -20,8 +20,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf52python3.14.____cp314qt_version6.yaml
+++ b/.ci_support/win_64_hdf52python3.14.____cp314qt_version6.yaml
@@ -20,8 +20,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_hdf52python3.14.____cp314qt_versionnone.yaml
+++ b/.ci_support/win_64_hdf52python3.14.____cp314qt_versionnone.yaml
@@ -20,8 +20,6 @@ hdf5:
 - '2'
 imath:
 - 3.2.2
-jasper:
-- '4'
 libavif:
 - '1'
 libcblas:
@@ -48,6 +46,8 @@ numpy:
 - '2'
 openexr:
 - '3.4'
+openjpeg:
+- '2'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,351 +23,421 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.10.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.10.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.11.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.11.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.12.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.12.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.13.____cp313qt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.13.____cp313qt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.14.____cp314qt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2025.4.1libprotobuf6.31.1python3.14.____cp314qt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.10.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.10.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.11.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.11.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.12.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.12.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.13.____cp313qt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.13.____cp313qt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.14.____cp314qt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf51.14.6libopenvino_dev2026.0.0libprotobuf6.33.5python3.14.____cp314qt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.10.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.10.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.11.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.11.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.12.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.12.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.13.____cp313qt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.13.____cp313qt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.14.____cp314qt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2025.4.1libprotobuf6.31.1python3.14.____cp314qt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.10.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.10.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.11.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.11.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.12.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.12.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.13.____cp313qt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.13.____cp313qt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.14.____cp314qt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_hdf52libopenvino_dev2026.0.0libprotobuf6.33.5python3.14.____cp314qt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf51.14.6python3.10.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf51.14.6python3.10.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf51.14.6python3.11.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf51.14.6python3.11.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf51.14.6python3.12.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf51.14.6python3.12.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf51.14.6python3.13.____cp313qt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf51.14.6python3.13.____cp313qt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf51.14.6python3.14.____cp314qt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf51.14.6python3.14.____cp314qt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf52python3.10.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf52python3.10.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf52python3.11.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf52python3.11.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf52python3.12.____cpythonqt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf52python3.12.____cpythonqt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf52python3.13.____cp313qt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf52python3.13.____cp313qt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf52python3.14.____cp314qt_version6
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_hdf52python3.14.____cp314qt_versionnone
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_ppc64le_hdf51.14.6python3.10.____cpython
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_ppc64le_hdf51.14.6python3.11.____cpython
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_ppc64le_hdf51.14.6python3.12.____cpython
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_ppc64le_hdf51.14.6python3.13.____cp313
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_ppc64le_hdf51.14.6python3.14.____cp314
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_ppc64le_hdf52python3.10.____cpython
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_ppc64le_hdf52python3.11.____cpython
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_ppc64le_hdf52python3.12.____cpython
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_ppc64le_hdf52python3.13.____cp313
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_ppc64le_hdf52python3.14.____cp314
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -444,7 +514,7 @@ jobs:
       env:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
+        CONDA_BLD_PATH: C:\bld
         MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -77,9 +77,9 @@ cmake -LAH -G "Ninja"                                                           
     -DWITH_OPENEXR=1                                                                ^
     -DBUILD_JPEGXL=0                                                                ^
     -DWITH_JPEGXL=1                                                                 ^
-    -DBUILD_JASPER=0                                                                ^
-    -DWITH_JASPER=1                                                                 ^
-    -DWITH_OPENJPEG=0                                                               ^
+    -DWITH_JASPER=0                                                                 ^
+    -DBUILD_OPENJPEG=0                                                              ^
+    -DWITH_OPENJPEG=1                                                               ^
     -DBUILD_JPEG=0                                                                  ^
     -DBUILD_WEBP=0                                                                  ^
     -DWITH_WEBP=1                                                                   ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -102,9 +102,9 @@ cmake -LAH -G "Ninja"                                                     \
     -DWITH_OPENEXR=1                                                      \
     -DBUILD_JPEGXL=0                                                      \
     -DWITH_JPEGXL=1                                                       \
-    -DBUILD_JASPER=0                                                      \
-    -DWITH_JASPER=1                                                       \
-    -DWITH_OPENJPEG=0                                                     \
+    -DWITH_JASPER=0                                                       \
+    -DBUILD_OPENJPEG=0                                                    \
+    -DWITH_OPENJPEG=1                                                     \
     -DBUILD_JPEG=0                                                        \
     -DBUILD_WEBP=0                                                        \
     -DWITH_WEBP=1                                                         \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -240,6 +240,7 @@ outputs:
         - if [[ $($PYTHON -c 'import cv2; print(cv2.__version__)') != $PKG_VERSION ]]; then exit 1; fi  # [unix]
         - python -c "import cv2; assert 'Unknown' not in cv2.videoio_registry.getBackendName(cv2.CAP_V4L)"  # [linux]
         - python -c "import cv2, re; assert re.search('Lapack:\s+YES', cv2.getBuildInformation())"
+        - python -c "import cv2, re; assert re.search(r'JPEG 2000:\s+OpenJPEG', cv2.getBuildInformation()), cv2.getBuildInformation()"
         - pip check
         - pip list
         - test $(pip list | grep "opencv-python " | wc -l) -eq 1           # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@
 {% set PY_VER_MAJOR = PY_VER.split('.')[0] %}
 {% set PY_VER_MINOR = PY_VER.split('.')[1] %}
 
-{% set build = 7 %}
+{% set build = 8 %}
 
 # Allow the qt version to be easily read from the build number 100's value.
 # This used to be more important when we supported both qt5 and qt6
@@ -106,7 +106,7 @@ requirements:
     # Ensure that we build with nompi variant
     # it provides downstream packages with the most flexibility
     - hdf5 * nompi*
-    - jasper
+    - openjpeg
     - libavif
     - libcblas
     - libiconv                       # [unix]


### PR DESCRIPTION
## Summary

Switch the JPEG2000 codec from JasPer to OpenJPEG. This aligns the recipe with
OpenCV's preferred default and with the pip-installed `opencv-python` wheels.

Concretely:
- `recipe/build.sh` and `recipe/bld.bat`: `WITH_JASPER=1 / WITH_OPENJPEG=0` →
  `WITH_JASPER=0 / WITH_OPENJPEG=1`. Also `BUILD_OPENJPEG=0` so the
  conda-forge `openjpeg` package is used (relevant on macOS/Windows where
  OpenCV's CMake otherwise defaults `BUILD_OPENJPEG` to ON).
- `recipe/meta.yaml`: replace `jasper` with `openjpeg` in `host:`.
- Bump build number 7 → 8.

## Why

### 1. The original reason for keeping JasPer is gone

The recipe was switched away from JasPer in
c2909f5 ("Use openjpeg, not jasper"), then reverted back in #243 ("Aarch and
ppc64le (without QT)"). The
[stated reason in #243](https://github.com/conda-forge/opencv-feedstock/pull/243#issuecomment-716445034)
was a packaging-logistics problem at the time: jasper was pinned to `1.900.1`
in `conda-forge-pinning`, only `1.900.31` was available on aarch/ppc, and the
Windows pin PR
([conda-forge-pinning-feedstock#659](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/659))
had been open for months
(see also
[conda-forge-pinning-feedstock#891](https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/891)).

Those pinning issues were resolved long ago, and #354 (2023) successfully
migrated to jasper 4.x across the whole matrix. The `WITH_JASPER=1 /
WITH_OPENJPEG=0` flags have not been revisited since the 2020 revert.

### 2. OpenCV upstream prefers OpenJPEG

In
[`cmake/OpenCVFindLibsGrfmt.cmake`](https://github.com/opencv/opencv/blob/4.x/cmake/OpenCVFindLibsGrfmt.cmake#L240-L291):

```cmake
# --- libopenjp2 (optional, check before libjasper) ---
if(WITH_OPENJPEG)
  ...
endif()

# --- libjasper (optional, should be searched after libjpeg) ---
if(WITH_JASPER AND NOT HAVE_OPENJPEG)   # ← JasPer skipped when OpenJPEG present
  ...
```

Both `WITH_OPENJPEG` and `WITH_JASPER` default to ON, but the CMake explicitly
says \"check before libjasper\" and skips JasPer when OpenJPEG is found. The
recipe's explicit `WITH_OPENJPEG=0` is what currently overrides that
preference.

JasPer 1.900 is also considered unsafe for untrusted input upstream
([opencv/opencv#14058](https://github.com/opencv/opencv/issues/14058)) — it is
runtime-disabled by default and requires `OPENCV_IO_ENABLE_JASPER=1` to
re-enable. The stated long-term plan in that issue is to replace JasPer with
OpenJPEG.

### 3. `opencv-python` (pip) ships OpenJPEG

`opencv-python`'s `setup.py` doesn't pass `WITH_*` flags, so it picks up
OpenCV's defaults. The manylinux Docker images don't install
`jasper-devel` / `openjpeg-devel`, so OpenCV's CMake:

1. fails `find_package(OpenJPEG)`,
2. builds the bundled `3rdparty/openjpeg` from source → `HAVE_OPENJPEG=YES`,
3. **skips JasPer entirely** because of `NOT HAVE_OPENJPEG`.

[`opencv-python/LICENSE-3RD-PARTY.txt`](https://github.com/opencv/opencv-python/blob/4.x/LICENSE-3RD-PARTY.txt)
confirms this:

> \"OpenJPEG library is redistributed within all opencv-python packages.\"

JasPer is not mentioned in that file. So a user `pip install opencv-python`
gets OpenJPEG today; this PR makes the conda-forge build behave the same way.

## Known caveat

[opencv/opencv#20527](https://github.com/opencv/opencv/issues/20527) — the
OpenJPEG-based JPEG2000 encoder has a long-standing correctness bug for some
images and isn't lossless. This affects writers of `.jp2` files. However:

- It also affects `opencv-python` users (they ship OpenJPEG anyway).
- OpenCV upstream has not switched the default away from OpenJPEG.
- Read-side users (the common case) are not affected.

Net: this is a real but already-broadly-accepted tradeoff. Worth flagging in
review, but it's the same tradeoff the rest of the OpenCV ecosystem has made.

## Checklist

- [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
- [x] Bumped the build number (7 → 8)
- [x] [Re-rendered](https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks) 